### PR TITLE
setting origin for articulation

### DIFF
--- a/examples/moving_robot.py
+++ b/examples/moving_robot.py
@@ -1,0 +1,69 @@
+import sapien.core as sapien
+import mplib
+import numpy as np
+from demo_setup import DemoSetup
+
+class PlanningDemo(DemoSetup):
+    def __init__(self):
+        super().__init__()
+        self.setup_scene()
+        self.load_robot(robot_origin_xyz=[1, 1, 0])
+        self.setup_planner()
+
+        self.planner.set_base_pose([1, 1, 0, 1, 0, 0, 0])
+
+        # Set initial joint positions
+        init_qpos = [0, 0.19634954084936207, 0.0, -2.617993877991494, 0.0, 2.941592653589793, 0.7853981633974483, 0, 0]
+        self.robot.set_qpos(init_qpos)
+
+        # table top
+        builder = self.scene.create_actor_builder()
+        builder.add_box_collision(half_size=[0.4, 0.4, 0.025])
+        builder.add_box_visual(half_size=[0.4, 0.4, 0.025])
+        self.table = builder.build_kinematic(name='table')
+        self.table.set_pose(sapien.Pose([1.56, 1, -0.025]))
+
+        # boxes
+        builder = self.scene.create_actor_builder()
+        builder.add_box_collision(half_size=[0.02, 0.02, 0.06])
+        builder.add_box_visual(half_size=[0.02, 0.02, 0.06], color=[1, 0, 0])
+        self.red_cube = builder.build(name='red_cube')
+        self.red_cube.set_pose(sapien.Pose([1.4, 1.3, 0.06]))
+
+        builder = self.scene.create_actor_builder()
+        builder.add_box_collision(half_size=[0.02, 0.02, 0.04])
+        builder.add_box_visual(half_size=[0.02, 0.02, 0.04], color=[0, 1, 0])
+        self.green_cube = builder.build(name='green_cube')
+        self.green_cube.set_pose(sapien.Pose([1.2, 0.7, 0.04]))
+
+        builder = self.scene.create_actor_builder()
+        builder.add_box_collision(half_size=[0.02, 0.02, 0.07])
+        builder.add_box_visual(half_size=[0.02, 0.02, 0.07], color=[0, 0, 1])
+        self.blue_cube = builder.build(name='blue_cube')
+        self.blue_cube.set_pose(sapien.Pose([1.6, 1.1, 0.07]))
+
+    def demo(self):
+        poses = [[0.4, 0.3, 0.12, 0, 1, 0, 0],
+                [0.2, -0.3, 0.08, 0, 1, 0, 0],
+                [0.6, 0.1, 0.14, 0, 1, 0, 0]]
+        for i in range(3):
+            pose = poses[i]
+            pose[2] += 0.2
+            self.move_to_pose(pose)
+            self.open_gripper()
+            pose[2] -= 0.12
+            self.move_to_pose(pose)
+            self.close_gripper()
+            pose[2] += 0.12
+            self.move_to_pose(pose)
+            pose[0] += 0.1
+            self.move_to_pose(pose)
+            pose[2] -= 0.12
+            self.move_to_pose(pose)
+            self.open_gripper()
+            pose[2] += 0.12
+            self.move_to_pose(pose)
+
+if __name__ == '__main__':
+    demo = PlanningDemo()
+    demo.demo()

--- a/python/pybind_articulation.hpp
+++ b/python/pybind_articulation.hpp
@@ -42,9 +42,8 @@ void build_pyarticulation(py::module &m_all) {
             .def("get_move_group_end_effectors", &ArticulatedModel::getMoveGroupEndEffectors)
             .def("get_qpos", &ArticulatedModel::getQpos)
             .def("get_qpos_dim", &ArticulatedModel::getQposDim)
-            .def("set_qpos", &ArticulatedModel::setQpos,
-                 py::arg("qpos"), py::arg("full") = false)
-            .def("update_SRDF", &ArticulatedModel::updateSRDF,
-                 py::arg("SRDF"));
-
+            .def("set_qpos", &ArticulatedModel::setQpos, py::arg("qpos"), py::arg("full") = false)
+            .def("update_SRDF", &ArticulatedModel::updateSRDF, py::arg("SRDF"))
+            .def("set_base_pose", &ArticulatedModel::setBasePose, py::arg("pose"))
+            .def("get_base_pose", &ArticulatedModel::getBasePose);
 }

--- a/src/articulated_model.h
+++ b/src/articulated_model.h
@@ -25,11 +25,18 @@ private:
     int qpos_dim;
     bool verbose;
 
+    // the base pose of the robot
+    Vector7 base_pose;
+    Transform3 base_tf;
 
 public:
-    ArticulatedModelTpl(std::string const &urdf_filename, std::string const &srdf_filename, Vector3 const &gravity,
-                        std::vector<std::string> const &joint_names = {}, std::vector<std::string> const &link_names = {},
-                        bool const &verbose=true, bool const &convex=false);
+    ArticulatedModelTpl(std::string const &urdf_filename,
+                        std::string const &srdf_filename,
+                        Vector3 const &gravity,
+                        std::vector<std::string> const &joint_names = {},
+                        std::vector<std::string> const &link_names = {},
+                        bool const &verbose=true,
+                        bool const &convex=false);
 
     PinocchioModelTpl<DATATYPE>& getPinocchioModel() { return pinocchio_model; }
 
@@ -55,7 +62,11 @@ public:
 
     void setQpos(VectorX const& qpos, bool const& full=false);
 
-    void updateSRDF(std::string const &srdf) {fcl_model.removeCollisionPairsFromSrdf(srdf);}
+    void updateSRDF(std::string const &srdf) { fcl_model.removeCollisionPairsFromSrdf(srdf); }
+
+    void setBasePose(const Vector7 &pose);
+
+    Vector7 getBasePose() { return base_pose; }
 };
 
 template<typename T>


### PR DESCRIPTION
[Screencast from 11-15-2023 09:11:07 PM.webm](https://github.com/haosulab/MPlib/assets/13091869/bd9b595a-a3cf-4c81-84cf-b51a3ba04c84)

You can now specify the base pose in the planner. Additionally, when requesting to plan to a new pose, one can either specify the pose w.r.t. the robot or w.r.t. the world.

Added demo usage