### PR TITLE
Unify pose; Support multi-shape Physx components in SapienPlanningWorld conversion

### DIFF
--- a/docs/source/reference/index.rst
+++ b/docs/source/reference/index.rst
@@ -8,6 +8,7 @@ API Reference
    PlanningWorld
    core/ArticulatedModel
    core/AttachedBody
+   utils/pose
    utils/random
 
 .. toctree::

--- a/docs/source/reference/utils/pose.rst
+++ b/docs/source/reference/utils/pose.rst
@@ -1,0 +1,7 @@
+``Pose``
+-------------------------
+
+.. autoclass:: mplib.pymp.Pose
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/tutorials/plan_a_path.rst
+++ b/docs/source/tutorials/plan_a_path.rst
@@ -92,7 +92,7 @@ In this example, we create some boxes inside the simulation like so:
    :start-after: # boxes ankor
    :end-before: # boxes ankor end
 
-We then find the target poses needed to reach the boxes. The poses are specified in [x,y,z,qw,qx,qy,qz]:
+We then find the target poses needed to reach the boxes.
 
 .. literalinclude:: ../../../mplib/examples/demo.py
    :dedent: 0

--- a/include/mplib/collision_detection/fcl/collision_common.h
+++ b/include/mplib/collision_detection/fcl/collision_common.h
@@ -9,6 +9,7 @@
 #include "mplib/collision_detection/fcl/types.h"
 #include "mplib/macros/class_forward.h"
 #include "mplib/types.h"
+#include "mplib/utils/pose.h"
 
 namespace mplib::collision_detection::fcl {
 
@@ -42,9 +43,9 @@ struct FCLObject {
    * @param shapes: all collision shapes as a vector of ``fcl::CollisionObjectPtr``
    * @param shape_poses: relative poses from this FCLObject to each collision shape
    */
-  FCLObject(const std::string &name, const Isometry3<S> &pose,
-            const std::vector<fcl::CollisionObjectPtr<S>> &shapes,
-            const std::vector<Isometry3<S>> &shape_poses);
+  FCLObject(const std::string &name_, const Pose<S> &pose_,
+            const std::vector<fcl::CollisionObjectPtr<S>> &shapes_,
+            const std::vector<Pose<S>> &shape_poses_);
 
   std::string name;   ///< Name of this FCLObject
   Isometry3<S> pose;  ///< Pose of this FCLObject. All shapes are relative to this pose

--- a/include/mplib/collision_detection/fcl/fcl_model.h
+++ b/include/mplib/collision_detection/fcl/fcl_model.h
@@ -12,7 +12,7 @@
 
 #include "mplib/collision_detection/fcl/collision_common.h"
 #include "mplib/macros/class_forward.h"
-#include "mplib/types.h"
+#include "mplib/utils/pose.h"
 
 namespace mplib::collision_detection::fcl {
 
@@ -125,14 +125,7 @@ class FCLModelTpl {
    *
    * @param link_poses: list of link poses in the order of the link order
    */
-  void updateCollisionObjects(const std::vector<Vector7<S>> &link_poses) const;
-
-  /**
-   * Update the collision objects of the FCL model.
-   *
-   * @param link_poses: list of link poses in the order of the link order
-   */
-  void updateCollisionObjects(const std::vector<Isometry3<S>> &link_poses) const;
+  void updateCollisionObjects(const std::vector<Pose<S>> &link_poses) const;
 
   /**
    * Perform self-collision checking.

--- a/include/mplib/core/articulated_model.h
+++ b/include/mplib/core/articulated_model.h
@@ -66,6 +66,7 @@ class ArticulatedModelTpl {
    * @param verbose: print debug information. Default: ``false``.
    * @return: a unique_ptr to ArticulatedModel
    */
+  // TODO(merge): remove pair (link name is not needed)
   static std::unique_ptr<ArticulatedModelTpl<S>> createFromURDFString(
       const std::string &urdf_string, const std::string &srdf_string,
       const std::vector<std::pair<std::string, collision_detection::FCLObjectPtr<S>>>

--- a/include/mplib/core/articulated_model.h
+++ b/include/mplib/core/articulated_model.h
@@ -9,7 +9,7 @@
 #include "mplib/kinematics/types.h"
 #include "mplib/macros/class_forward.h"
 #include "mplib/types.h"
-#include "mplib/utils/conversion.h"
+#include "mplib/utils/pose.h"
 
 namespace mplib {
 
@@ -176,7 +176,7 @@ class ArticulatedModelTpl {
   const VectorX<S> &getQpos() const { return current_qpos_; }
 
   /**
-   * Let the planner know the current joint positions.
+   * Set the current joint positions and update all collision links in the ``FCLModel``.
    *
    * @param qpos: current qpos of all active joints or just the move group joints
    * @param full: whether to set the full qpos or just the move group qpos.
@@ -186,18 +186,21 @@ class ArticulatedModelTpl {
   void setQpos(const VectorX<S> &qpos, bool full = false);
 
   /**
-   * Get the base pose of the robot.
+   * Get the base (root) pose of the robot.
    *
-   * @return: base pose of the robot in [x, y, z, qw, qx, qy, qz] format
+   * @return: base pose of the robot
    */
-  Vector7<S> getBasePose() const { return toPoseVec<S>(base_pose_); }
+  Pose<S> getBasePose() const { return Pose<S>(base_pose_); }
 
   /**
-   * Set the base pose of the robot.
+   * Set the base pose of the robot and update all collision links in the ``FCLModel``.
    *
-   * @param pose: base pose of the robot in [x, y, z, qw, qx, qy, qz] format
+   * @param pose: base pose of the robot
    */
-  void setBasePose(const Vector7<S> &pose);
+  void setBasePose(const Pose<S> &pose) {
+    base_pose_ = pose.toIsometry();
+    setQpos(current_qpos_, true);  // update all collision links in the fcl_model_
+  }
 
   /**
    * Update the SRDF file to disable self-collisions.

--- a/include/mplib/core/attached_body.h
+++ b/include/mplib/core/attached_body.h
@@ -8,7 +8,7 @@
 #include "mplib/kinematics/types.h"
 #include "mplib/macros/class_forward.h"
 #include "mplib/types.h"
-#include "mplib/utils/conversion.h"
+#include "mplib/utils/pose.h"
 
 namespace mplib {
 
@@ -42,7 +42,7 @@ class AttachedBodyTpl {
    */
   AttachedBodyTpl(const std::string &name, const FCLObjectPtr &object,
                   const ArticulatedModelPtr &attached_articulation,
-                  int attached_link_id, const Isometry3<S> &pose,
+                  int attached_link_id, const Pose<S> &pose,
                   const std::vector<std::string> &touch_links = {});
 
   /// @brief Gets the attached object name
@@ -65,7 +65,7 @@ class AttachedBodyTpl {
 
   /// @brief Gets the global pose of the attached object
   Isometry3<S> getGlobalPose() const {
-    return toIsometry(pinocchio_model_->getLinkPose(attached_link_id_)) * pose_;
+    return pinocchio_model_->getLinkPose(attached_link_id_) * pose_;
   }
 
   /// @brief Updates the global pose of the attached object using current state

--- a/include/mplib/core/attached_body.h
+++ b/include/mplib/core/attached_body.h
@@ -51,10 +51,10 @@ class AttachedBodyTpl {
   /// @brief Gets the attached object (``FCLObjectPtr``)
   FCLObjectPtr getObject() const { return object_; }
 
-  /// @brief Gets the articulation this body is attached to
+  /// @brief Gets the articulation that this body is attached to
   ArticulatedModelPtr getAttachedArticulation() const { return attached_articulation_; }
 
-  /// @brief Gets the articulation this body is attached to
+  /// @brief Gets the articulation link id that this body is attached to
   int getAttachedLinkId() const { return attached_link_id_; }
 
   /// @brief Gets the attached pose (relative pose from attached link to object)
@@ -63,10 +63,13 @@ class AttachedBodyTpl {
   /// @brief Sets the attached pose (relative pose from attached link to object)
   void setPose(const Isometry3<S> &pose) { pose_ = pose; }
 
-  /// @brief Gets the global pose of the attached object
-  Isometry3<S> getGlobalPose() const {
-    return pinocchio_model_->getLinkPose(attached_link_id_) * pose_;
+  /// @brief Gets the global pose of the articulation link that this body is attached to
+  Isometry3<S> getAttachedLinkGlobalPose() const {
+    return pinocchio_model_->getLinkPose(attached_link_id_);
   }
+
+  /// @brief Gets the global pose of the attached object
+  Isometry3<S> getGlobalPose() const { return getAttachedLinkGlobalPose() * pose_; }
 
   /// @brief Updates the global pose of the attached object using current state
   void updatePose() const;

--- a/include/mplib/kinematics/kdl/kdl_model.h
+++ b/include/mplib/kinematics/kdl/kdl_model.h
@@ -9,6 +9,7 @@
 
 #include "mplib/macros/class_forward.h"
 #include "mplib/types.h"
+#include "mplib/utils/pose.h"
 
 namespace mplib::kinematics::kdl {
 
@@ -30,19 +31,18 @@ class KDLModelTpl {
   const std::string &getTreeRootName() const { return tree_root_name_; }
 
   std::tuple<VectorX<S>, int> chainIKLMA(size_t index, const VectorX<S> &q0,
-                                         const Vector7<S> &pose) const;
+                                         const Pose<S> &pose) const;
 
   std::tuple<VectorX<S>, int> chainIKNR(size_t index, const VectorX<S> &q0,
-                                        const Vector7<S> &pose) const;
+                                        const Pose<S> &pose) const;
 
   std::tuple<VectorX<S>, int> chainIKNRJL(size_t index, const VectorX<S> &q0,
-                                          const Vector7<S> &pose,
-                                          const VectorX<S> &q_min,
+                                          const Pose<S> &pose, const VectorX<S> &q_min,
                                           const VectorX<S> &q_max) const;
 
   std::tuple<VectorX<S>, int> TreeIKNRJL(const std::vector<std::string> endpoints,
                                          const VectorX<S> &q0,
-                                         const std::vector<Vector7<S>> &poses,
+                                         const std::vector<Pose<S>> &poses,
                                          const VectorX<S> &q_min,
                                          const VectorX<S> &q_max) const;
 

--- a/include/mplib/kinematics/pinocchio/pinocchio_model.h
+++ b/include/mplib/kinematics/pinocchio/pinocchio_model.h
@@ -14,6 +14,7 @@
 #include "mplib/kinematics/pinocchio/types.h"
 #include "mplib/macros/class_forward.h"
 #include "mplib/types.h"
+#include "mplib/utils/pose.h"
 
 namespace mplib::kinematics::pinocchio {
 
@@ -266,15 +267,15 @@ class PinocchioModelTpl {
   void computeForwardKinematics(const VectorX<S> &qpos);
 
   /**
-   * Get the pose of the given link.
+   * Get the pose of the given link in robot's base (root) frame.
    *
    * @param index: index of the link (in the order you passed to the constructor or the
    *    default order)
-   * @return: pose of the link [x, y, z, qw, qx, qy, qz]
+   * @return: pose of the link in robot's base (root) frame.
    */
-  Vector7<S> getLinkPose(size_t index) const;
+  Isometry3<S> getLinkPose(size_t index) const;
 
-  Vector7<S> getJointPose(size_t index) const;  // TODO: not same as sapien
+  Isometry3<S> getJointPose(size_t index) const;  // TODO: not same as sapien
 
   /**
    * Compute the full jacobian for the given joint configuration.
@@ -318,7 +319,7 @@ class PinocchioModelTpl {
    *
    * @param index: index of the link (in the order you passed to the constructor or the
    *    default order)
-   * @param pose: desired pose of the link [x, y, z, qw, qx, qy, qz]
+   * @param pose: desired pose of the link
    * @param q_init: initial joint configuration
    * @param mask: if the value at a given index is ``true``, the joint is *not* used in
    *    the IK
@@ -329,7 +330,7 @@ class PinocchioModelTpl {
    * @return: joint configuration
    */
   std::tuple<VectorX<S>, bool, Vector6<S>> computeIKCLIK(
-      size_t index, const Vector7<S> &pose, const VectorX<S> &q_init,
+      size_t index, const Pose<S> &pose, const VectorX<S> &q_init,
       const std::vector<bool> &mask, double eps = 1e-5, int max_iter = 1000,
       double dt = 1e-1, double damp = 1e-12);
 
@@ -339,7 +340,7 @@ class PinocchioModelTpl {
    *
    * @param index: index of the link (in the order you passed to the constructor or the
    *    default order)
-   * @param pose: desired pose of the link [x, y, z, qw, qx, qy, qz]
+   * @param pose: desired pose of the link
    * @param q_init: initial joint configuration
    * @param q_min: minimum joint configuration
    * @param q_max: maximum joint configuration
@@ -350,7 +351,7 @@ class PinocchioModelTpl {
    * @return: joint configuration
    */
   std::tuple<VectorX<S>, bool, Vector6<S>> computeIKCLIKJL(
-      size_t index, const Vector7<S> &pose, const VectorX<S> &q_init,
+      size_t index, const Pose<S> &pose, const VectorX<S> &q_init,
       const VectorX<S> &qmin, const VectorX<S> &qmax, double eps = 1e-5,
       int max_iter = 1000, double dt = 1e-1, double damp = 1e-12);
 

--- a/include/mplib/planning_world.h
+++ b/include/mplib/planning_world.h
@@ -10,6 +10,7 @@
 #include "mplib/core/attached_body.h"
 #include "mplib/macros/class_forward.h"
 #include "mplib/types.h"
+#include "mplib/utils/pose.h"
 
 namespace mplib {
 
@@ -265,8 +266,7 @@ class PlanningWorldTpl {
    *  or if planned articulation with given name does not exist
    */
   void attachObject(const std::string &name, const std::string &art_name, int link_id,
-                    const Vector7<S> &pose,
-                    const std::vector<std::string> &touch_links);
+                    const Pose<S> &pose, const std::vector<std::string> &touch_links);
 
   /**
    * Attaches existing normal object to specified link of articulation at given pose.
@@ -284,7 +284,7 @@ class PlanningWorldTpl {
    *  or if planned articulation with given name does not exist
    */
   void attachObject(const std::string &name, const std::string &art_name, int link_id,
-                    const Vector7<S> &pose);
+                    const Pose<S> &pose);
 
   /**
    * Attaches given object (w/ p_geom) to specified link of articulation at given pose.
@@ -299,7 +299,7 @@ class PlanningWorldTpl {
    * @param touch_links: link names that the attached object touches
    */
   void attachObject(const std::string &name, const CollisionGeometryPtr &p_geom,
-                    const std::string &art_name, int link_id, const Vector7<S> &pose,
+                    const std::string &art_name, int link_id, const Pose<S> &pose,
                     const std::vector<std::string> &touch_links);
 
   /**
@@ -316,7 +316,7 @@ class PlanningWorldTpl {
    * @param pose: attached pose (relative pose from attached link to object)
    */
   void attachObject(const std::string &name, const CollisionGeometryPtr &p_geom,
-                    const std::string &art_name, int link_id, const Vector7<S> &pose);
+                    const std::string &art_name, int link_id, const Pose<S> &pose);
 
   /**
    * Attaches given sphere to specified link of articulation (auto touch_links)
@@ -327,7 +327,7 @@ class PlanningWorldTpl {
    * @param pose: attached pose (relative pose from attached link to object)
    */
   void attachSphere(S radius, const std::string &art_name, int link_id,
-                    const Vector7<S> &pose);
+                    const Pose<S> &pose);
 
   /**
    * Attaches given box to specified link of articulation (auto touch_links)
@@ -338,7 +338,7 @@ class PlanningWorldTpl {
    * @param pose: attached pose (relative pose from attached link to object)
    */
   void attachBox(const Vector3<S> &size, const std::string &art_name, int link_id,
-                 const Vector7<S> &pose);
+                 const Pose<S> &pose);
 
   /**
    * Attaches given mesh to specified link of articulation (auto touch_links)
@@ -349,7 +349,7 @@ class PlanningWorldTpl {
    * @param pose: attached pose (relative pose from attached link to object)
    */
   void attachMesh(const std::string &mesh_path, const std::string &art_name,
-                  int link_id, const Vector7<S> &pose);
+                  int link_id, const Pose<S> &pose);
 
   /**
    * Detaches object with given name.

--- a/include/mplib/types.h
+++ b/include/mplib/types.h
@@ -15,9 +15,6 @@ template <typename S>
 using Vector6 = Eigen::Matrix<S, 6, 1>;
 
 template <typename S>
-using Vector7 = Eigen::Matrix<S, 7, 1>;
-
-template <typename S>
 using VectorX = Eigen::Matrix<S, Eigen::Dynamic, 1>;
 
 using Vector3i = Eigen::Vector3i;

--- a/include/mplib/utils/conversion.h
+++ b/include/mplib/utils/conversion.h
@@ -9,14 +9,6 @@
 
 namespace mplib {
 
-/// Converts an Eigen::Isometry3 matrix to a pose_vec [px, py, pz, qw, qx, qy, qz]
-template <typename S>
-Vector7<S> toPoseVec(const Isometry3<S> &pose);
-
-/// Converts a pose_vec [px, py, pz, qw, qx, qy, qz] to an Eigen::Isometry3 matrix
-template <typename S>
-Isometry3<S> toIsometry(const Vector7<S> &pose_vec);
-
 template <typename S>
 Isometry3<S> toIsometry(const pinocchio::SE3Tpl<S> &T);
 
@@ -37,8 +29,6 @@ pinocchio::InertiaTpl<S> convertInertial(const urdf::InertialSharedPtr &Y);
 
 // Explicit Template Instantiation Declaration =========================================
 #define DECLARE_TEMPLATE_CONVERSION(S)                                       \
-  extern template Vector7<S> toPoseVec<S>(const Isometry3<S> &pose);         \
-  extern template Isometry3<S> toIsometry<S>(const Vector7<S> &pose_vec);    \
   extern template Isometry3<S> toIsometry<S>(const pinocchio::SE3Tpl<S> &T); \
   extern template Isometry3<S> toIsometry<S>(const urdf::Pose &M);           \
   extern template pinocchio::SE3Tpl<S> toSE3<S>(const Isometry3<S> &T);      \

--- a/include/mplib/utils/pose.h
+++ b/include/mplib/utils/pose.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#include "mplib/types.h"
+
+namespace mplib {
+
+/// @brief Pose stored as a unit quaternion and a position vector
+template <typename S>
+struct Pose {
+  /// @brief Constructs a default Pose with p = (0,0,0) and q = (1,0,0,0)
+  Pose() : p(0.0, 0.0, 0.0), q(1.0, 0.0, 0.0, 0.0) {}
+
+  /**
+   * Constructs a Pose with given position and quaternion
+   *
+   * @param p: position, format: (x, y, z)
+   * @param q: quaternion (can be unnormalized), format: (w, x, y, z)
+   */
+  Pose(const Vector3<S> &p, const Vector4<S> &q)
+      : p(p), q(Quaternion<S> {q(0), q(1), q(2), q(3)}.normalized()) {}
+
+  /**
+   * Constructs a Pose with given position and quaternion
+   *
+   * @param p: position, format: (x, y, z)
+   * @param q: quaternion (can be unnormalized), format: (w, x, y, z)
+   */
+  Pose(const Vector3<S> &p, const Quaternion<S> &q) : p(p), q(q.normalized()) {}
+
+  /**
+   * Get the inserse Pose
+   *
+   * @return: the inverse Pose
+   */
+  Pose<S> inverse() const {
+    Quaternion<S> qinv = q.conjugate();  // can use conjugate() since always normalized
+    return {qinv * -p, qinv};
+  }
+
+  /// @brief Overloading operator * for ``Pose<S> * Vector3<S>``
+  Vector3<S> operator*(const Vector3<S> &v) const { return q * v + p; };
+
+  /// @brief Overloading operator * for ``Pose<S> * Pose<S>``
+  Pose<S> operator*(const Pose<S> &other) const {
+    return {q * other.p + p, q * other.q};
+  };
+
+  /// @brief Overloading operator *= for ``Pose<S> *= Pose<S>``
+  Pose<S> &operator*=(const Pose<S> &other) {
+    *this = *this * other;
+    return *this;
+  };
+
+  /// @brief Overloading operator <<
+  friend std::ostream &operator<<(std::ostream &out, const Pose<S> &pose) {
+    out << "Pose([" << pose.p(0) << ", " << pose.p(1) << ", " << pose.p(2) << "], ["
+        << pose.q.w() << ", " << pose.q.x() << ", " << pose.q.y() << ", " << pose.q.z()
+        << "])";
+    return out;
+  }
+
+  Vector3<S> p {0.0, 0.0, 0.0};          ///< Position part of the Pose (x, y, z)
+  Quaternion<S> q {1.0, 0.0, 0.0, 0.0};  ///< Quaternion part of the Pose (w, x, y, z)
+};
+
+}  // namespace mplib

--- a/mplib/__init__.py
+++ b/mplib/__init__.py
@@ -4,6 +4,7 @@ from mplib.planner import Planner
 from mplib.pymp import (
     ArticulatedModel,
     PlanningWorld,
+    Pose,
     collision_detection,
     kinematics,
     planning,

--- a/mplib/examples/demo_setup.py
+++ b/mplib/examples/demo_setup.py
@@ -4,6 +4,7 @@ import sapien.core as sapien
 from sapien.utils.viewer import Viewer
 
 import mplib
+from mplib import Pose
 
 
 class DemoSetup:
@@ -160,12 +161,12 @@ class DemoSetup:
     def close_gripper(self):
         self.set_gripper(0)
 
-    def move_to_pose_with_RRTConnect(self, pose):
+    def move_to_pose_with_RRTConnect(self, pose: Pose):
         """
         Plan and follow a path to a pose using RRTConnect
 
         Args:
-            pose: [x, y, z, qx, qy, qz, qw]
+            pose: mplib.Pose
         """
         # result is a dictionary with keys 'status', 'time', 'position', 'velocity',
         # 'acceleration', 'duration'

--- a/mplib/pymp/__init__.pyi
+++ b/mplib/pymp/__init__.pyi
@@ -12,6 +12,7 @@ __all__ = [
     "ArticulatedModel",
     "AttachedBody",
     "PlanningWorld",
+    "Pose",
     "collision_detection",
     "kinematics",
     "planning",
@@ -728,6 +729,158 @@ class PlanningWorld:
         """
         Set qpos of all planned articulations
         """
+
+class Pose:
+    """
+    Pose stored as a unit quaternion and a position vector
+    """
+    def __getstate__(self) -> tuple: ...
+    def __imul__(self, other: Pose) -> Pose:
+        """
+        Overloading operator *= for ``Pose<S> *= Pose<S>``
+        """
+    @typing.overload
+    def __init__(self) -> None:
+        """
+        Constructs a default Pose with p = (0,0,0) and q = (1,0,0,0)
+        """
+    @typing.overload
+    def __init__(
+        self,
+        p: numpy.ndarray[
+            tuple[typing.Literal[3], typing.Literal[1]], numpy.dtype[numpy.float64]
+        ] = ...,
+        q: numpy.ndarray[
+            tuple[typing.Literal[4], typing.Literal[1]], numpy.dtype[numpy.float64]
+        ] = ...,
+    ) -> None:
+        """
+        Constructs a Pose with given position and quaternion
+
+        :param p: position, format: (x, y, z)
+        :param q: quaternion (can be unnormalized), format: (w, x, y, z)
+        """
+    @typing.overload
+    def __init__(
+        self,
+        matrix: numpy.ndarray[
+            tuple[typing.Literal[4], typing.Literal[4]], numpy.dtype[numpy.float64]
+        ],
+    ) -> None:
+        """
+        Constructs a Pose with given transformation matrix
+
+        :param matrix: a 4x4 transformation matrix
+        """
+    @typing.overload
+    def __mul__(
+        self,
+        v: numpy.ndarray[
+            tuple[typing.Literal[3], typing.Literal[1]], numpy.dtype[numpy.float64]
+        ],
+    ) -> numpy.ndarray[
+        tuple[typing.Literal[3], typing.Literal[1]], numpy.dtype[numpy.float64]
+    ]:
+        """
+        Overloading operator * for ``Pose<S> * Vector3<S>``
+        """
+    @typing.overload
+    def __mul__(self, other: Pose) -> Pose:
+        """
+        Overloading operator * for ``Pose<S> * Pose<S>``
+        """
+    def __repr__(self) -> str: ...
+    def __setstate__(self, arg0: tuple) -> None: ...
+    def get_p(
+        self,
+    ) -> numpy.ndarray[
+        tuple[typing.Literal[3], typing.Literal[1]], numpy.dtype[numpy.float64]
+    ]:
+        """
+        Gets the position part of the Pose
+
+        :return: position, format: (x, y, z)
+        """
+    def get_q(
+        self,
+    ) -> numpy.ndarray[
+        tuple[typing.Literal[4], typing.Literal[1]], numpy.dtype[numpy.float64]
+    ]:
+        """
+        Gets the quaternion part of the Pose
+
+        :return: quaternion, format: (w, x, y, z)
+        """
+    def inv(self) -> Pose:
+        """
+        Get the inserse Pose
+
+        :return: the inverse Pose
+        """
+    def set_p(
+        self,
+        p: numpy.ndarray[
+            tuple[typing.Literal[3], typing.Literal[1]], numpy.dtype[numpy.float64]
+        ],
+    ) -> None:
+        """
+        Sets the position part of the Pose
+
+        :param p: position, format: (x, y, z)
+        """
+    def set_q(
+        self,
+        q: numpy.ndarray[
+            tuple[typing.Literal[4], typing.Literal[1]], numpy.dtype[numpy.float64]
+        ],
+    ) -> None:
+        """
+        Sets the quaternion part of the Pose
+
+        :param q: quaternion (can be unnormalized), format: (w, x, y, z)
+        """
+    def to_transformation_matrix(
+        self,
+    ) -> numpy.ndarray[
+        tuple[typing.Literal[4], typing.Literal[4]], numpy.dtype[numpy.float64]
+    ]:
+        """
+        Constructs a transformation matrix from this Pose
+
+        :return: a 4x4 transformation matrix
+        """
+    @property
+    def p(
+        self,
+    ) -> numpy.ndarray[
+        tuple[typing.Literal[3], typing.Literal[1]], numpy.dtype[numpy.float64]
+    ]:
+        """
+        Position part of the Pose (x, y, z)
+        """
+    @p.setter
+    def p(
+        self,
+        arg0: numpy.ndarray[
+            tuple[typing.Literal[3], typing.Literal[1]], numpy.dtype[numpy.float64]
+        ],
+    ) -> None: ...
+    @property
+    def q(
+        self,
+    ) -> numpy.ndarray[
+        tuple[typing.Literal[4], typing.Literal[1]], numpy.dtype[numpy.float64]
+    ]:
+        """
+        Quaternion part of the Pose (w, x, y, z)
+        """
+    @q.setter
+    def q(
+        self,
+        arg1: numpy.ndarray[
+            tuple[typing.Literal[4], typing.Literal[1]], numpy.dtype[numpy.float64]
+        ],
+    ) -> None: ...
 
 def set_global_seed(seed: int) -> None:
     """

--- a/mplib/pymp/__init__.pyi
+++ b/mplib/pymp/__init__.pyi
@@ -774,8 +774,18 @@ class Pose:
     ) -> None:
         """
         Constructs a Pose with given transformation matrix
+        (4x4 np.ndarray with np.float64 dtype)
 
-        :param matrix: a 4x4 transformation matrix
+        :param matrix: a 4x4 np.float64 np.ndarray transformation matrix
+        """
+    @typing.overload
+    def __init__(self, obj: typing.Any) -> None:
+        """
+        Constructs a Pose with given Python object that has ``p`` and ``q`` attributes
+        (e.g., ``sapien.Pose``) or a 4x4 np.ndarray transformation matrix.
+
+        :param obj: a Pose-like object with ``p`` and ``q`` attributes or
+            a 4x4 np.ndarray transformation matrix
         """
     @typing.overload
     def __mul__(

--- a/mplib/pymp/__init__.pyi
+++ b/mplib/pymp/__init__.pyi
@@ -77,15 +77,11 @@ class ArticulatedModel:
             ``False``.
         :param verbose: print debug information. Default: ``False``.
         """
-    def get_base_pose(
-        self,
-    ) -> numpy.ndarray[
-        tuple[typing.Literal[7], typing.Literal[1]], numpy.dtype[numpy.float64]
-    ]:
+    def get_base_pose(self) -> Pose:
         """
-        Get the base pose of the robot.
+        Get the base (root) pose of the robot.
 
-        :return: base pose of the robot in [x, y, z, qw, qx, qy, qz] format
+        :return: base pose of the robot
         """
     def get_fcl_model(self) -> collision_detection.fcl.FCLModel:
         """
@@ -129,6 +125,12 @@ class ArticulatedModel:
 
         :return: Pinocchio model used for kinematics and dynamics computations
         """
+    def get_pose(self) -> Pose:
+        """
+        Get the base (root) pose of the robot.
+
+        :return: base pose of the robot
+        """
     def get_qpos(
         self,
     ) -> numpy.ndarray[tuple[M, typing.Literal[1]], numpy.dtype[numpy.float64]]:
@@ -149,16 +151,12 @@ class ArticulatedModel:
 
         :return: list of link names of the user
         """
-    def set_base_pose(
-        self,
-        pose: numpy.ndarray[
-            tuple[typing.Literal[7], typing.Literal[1]], numpy.dtype[numpy.float64]
-        ],
-    ) -> None:
+    def set_base_pose(self, pose: Pose) -> None:
         """
-        Set the base pose of the robot.
+        Set the base pose of the robot and update all collision links in the
+        ``FCLModel``.
 
-        :param pose: base pose of the robot in [x, y, z, qw, qx, qy, qz] format
+        :param pose: base pose of the robot
         """
     @typing.overload
     def set_move_group(self, end_effector: str) -> None:
@@ -182,13 +180,21 @@ class ArticulatedModel:
 
         @param: name of the articulated model
         """
+    def set_pose(self, pose: Pose) -> None:
+        """
+        Set the base pose of the robot and update all collision links in the
+        ``FCLModel``.
+
+        :param pose: base pose of the robot
+        """
     def set_qpos(
         self,
         qpos: numpy.ndarray[tuple[M, typing.Literal[1]], numpy.dtype[numpy.float64]],
         full: bool = False,
     ) -> None:
         """
-        Let the planner know the current joint positions.
+        Set the current joint positions and update all collision links in the
+        ``FCLModel``.
 
         :param qpos: current qpos of all active joints or just the move group joints
         :param full: whether to set the full qpos or just the move group qpos. If full
@@ -200,6 +206,34 @@ class ArticulatedModel:
         Update the SRDF file to disable self-collisions.
 
         :param srdf: path to SRDF file, can be relative to the current working directory
+        """
+    @property
+    def base_pose(self) -> Pose:
+        """
+        The base (root) pose of the robot
+        """
+    @base_pose.setter
+    def base_pose(self, arg1: Pose) -> None: ...
+    @property
+    def name(self) -> str:
+        """
+        Name of the articulated model
+        """
+    @name.setter
+    def name(self, arg1: str) -> None: ...
+    @property
+    def pose(self) -> Pose:
+        """
+        The base (root) pose of the robot
+        """
+    @pose.setter
+    def pose(self, arg1: Pose) -> None: ...
+    @property
+    def qpos(
+        self,
+    ) -> numpy.ndarray[tuple[M, typing.Literal[1]], numpy.dtype[numpy.float64]]:
+        """
+        Current qpos of all active joints
         """
 
 class AttachedBody:
@@ -217,9 +251,7 @@ class AttachedBody:
         object: collision_detection.fcl.FCLObject,
         attached_articulation: ArticulatedModel,
         attached_link_id: int,
-        pose: numpy.ndarray[
-            tuple[typing.Literal[7], typing.Literal[1]], numpy.dtype[numpy.float64]
-        ],
+        pose: Pose,
         touch_links: list[str] = [],
     ) -> None:
         """
@@ -240,7 +272,7 @@ class AttachedBody:
         """
         Gets the articulation this body is attached to
         """
-    def get_global_pose(self) -> ...:
+    def get_global_pose(self) -> Pose:
         """
         Gets the global pose of the attached object
         """
@@ -252,7 +284,7 @@ class AttachedBody:
         """
         Gets the attached object (``FCLObjectPtr``)
         """
-    def get_pose(self) -> ...:
+    def get_pose(self) -> Pose:
         """
         Gets the attached pose (relative pose from attached link to object)
         """
@@ -260,12 +292,7 @@ class AttachedBody:
         """
         Gets the link names that the attached body touches
         """
-    def set_pose(
-        self,
-        pose: numpy.ndarray[
-            tuple[typing.Literal[7], typing.Literal[1]], numpy.dtype[numpy.float64]
-        ],
-    ) -> None:
+    def set_pose(self, pose: Pose) -> None:
         """
         Sets the attached pose (relative pose from attached link to object)
         """
@@ -277,6 +304,13 @@ class AttachedBody:
         """
         Updates the global pose of the attached object using current state
         """
+    @property
+    def pose(self) -> Pose:
+        """
+        The attached pose (relative pose from attached link to object)
+        """
+    @pose.setter
+    def pose(self, arg1: Pose) -> None: ...
 
 class PlanningWorld:
     """
@@ -357,9 +391,7 @@ class PlanningWorld:
         ],
         art_name: str,
         link_id: int,
-        pose: numpy.ndarray[
-            tuple[typing.Literal[7], typing.Literal[1]], numpy.dtype[numpy.float64]
-        ],
+        pose: Pose,
     ) -> None:
         """
         Attaches given box to specified link of articulation (auto touch_links)
@@ -370,13 +402,7 @@ class PlanningWorld:
         :param pose: attached pose (relative pose from attached link to object)
         """
     def attach_mesh(
-        self,
-        mesh_path: str,
-        art_name: str,
-        link_id: int,
-        pose: numpy.ndarray[
-            tuple[typing.Literal[7], typing.Literal[1]], numpy.dtype[numpy.float64]
-        ],
+        self, mesh_path: str, art_name: str, link_id: int, pose: Pose
     ) -> None:
         """
         Attaches given mesh to specified link of articulation (auto touch_links)
@@ -421,14 +447,7 @@ class PlanningWorld:
         """
     @typing.overload
     def attach_object(
-        self,
-        name: str,
-        art_name: str,
-        link_id: int,
-        pose: numpy.ndarray[
-            tuple[typing.Literal[7], typing.Literal[1]], numpy.dtype[numpy.float64]
-        ],
-        touch_links: list[str],
+        self, name: str, art_name: str, link_id: int, pose: Pose, touch_links: list[str]
     ) -> None:
         """
         Attaches existing normal object to specified link of articulation at given pose.
@@ -445,15 +464,7 @@ class PlanningWorld:
             planned articulation with given name does not exist
         """
     @typing.overload
-    def attach_object(
-        self,
-        name: str,
-        art_name: str,
-        link_id: int,
-        pose: numpy.ndarray[
-            tuple[typing.Literal[7], typing.Literal[1]], numpy.dtype[numpy.float64]
-        ],
-    ) -> None:
+    def attach_object(self, name: str, art_name: str, link_id: int, pose: Pose) -> None:
         """
         Attaches existing normal object to specified link of articulation at given pose.
         If the object is not currently attached, automatically sets touch_links as the
@@ -476,9 +487,7 @@ class PlanningWorld:
         p_geom: collision_detection.fcl.CollisionGeometry,
         art_name: str,
         link_id: int,
-        pose: numpy.ndarray[
-            tuple[typing.Literal[7], typing.Literal[1]], numpy.dtype[numpy.float64]
-        ],
+        pose: Pose,
         touch_links: list[str],
     ) -> None:
         """
@@ -500,9 +509,7 @@ class PlanningWorld:
         p_geom: collision_detection.fcl.CollisionGeometry,
         art_name: str,
         link_id: int,
-        pose: numpy.ndarray[
-            tuple[typing.Literal[7], typing.Literal[1]], numpy.dtype[numpy.float64]
-        ],
+        pose: Pose,
     ) -> None:
         """
         Attaches given object (w/ p_geom) to specified link of articulation at given
@@ -518,13 +525,7 @@ class PlanningWorld:
         :param pose: attached pose (relative pose from attached link to object)
         """
     def attach_sphere(
-        self,
-        radius: float,
-        art_name: str,
-        link_id: int,
-        pose: numpy.ndarray[
-            tuple[typing.Literal[7], typing.Literal[1]], numpy.dtype[numpy.float64]
-        ],
+        self, radius: float, art_name: str, link_id: int, pose: Pose
     ) -> None:
         """
         Attaches given sphere to specified link of articulation (auto touch_links)
@@ -733,6 +734,10 @@ class PlanningWorld:
 class Pose:
     """
     Pose stored as a unit quaternion and a position vector
+
+    This struct is intended to be used only for interfacing with Python. Internally,
+    ``Pose`` is converted to and stored as ``Eigen::Isometry3`` which is used by all
+    computations.
     """
     def __getstate__(self) -> tuple: ...
     def __imul__(self, other: Pose) -> Pose:
@@ -791,6 +796,16 @@ class Pose:
         """
     def __repr__(self) -> str: ...
     def __setstate__(self, arg0: tuple) -> None: ...
+    def distance(self, other: Pose) -> float:
+        """
+        Computes the distance between two poses by ``norm(p1.p - p2.p) + min(norm(p1.q -
+        p2.q), norm(p1.q + p2.q))`.
+
+        The quaternion part has range [0, sqrt(2)].
+
+        :param other: the other pose
+        :return: the distance between the two poses
+        """
     def get_p(
         self,
     ) -> numpy.ndarray[

--- a/mplib/pymp/__init__.pyi
+++ b/mplib/pymp/__init__.pyi
@@ -266,11 +266,15 @@ class AttachedBody:
         """
     def get_attached_articulation(self) -> ArticulatedModel:
         """
-        Gets the articulation this body is attached to
+        Gets the articulation that this body is attached to
+        """
+    def get_attached_link_global_pose(self) -> Pose:
+        """
+        Gets the global pose of the articulation link that this body is attached to
         """
     def get_attached_link_id(self) -> int:
         """
-        Gets the articulation this body is attached to
+        Gets the articulation link id that this body is attached to
         """
     def get_global_pose(self) -> Pose:
         """

--- a/mplib/pymp/collision_detection/fcl.pyi
+++ b/mplib/pymp/collision_detection/fcl.pyi
@@ -6,6 +6,8 @@ import typing
 
 import numpy
 
+import mplib.pymp
+
 __all__ = [
     "BVHModel",
     "Box",
@@ -224,39 +226,34 @@ class CollisionObject:
     geometry.
     """
     def __init__(
-        self,
-        collision_geometry: CollisionGeometry,
-        position: numpy.ndarray[
-            tuple[typing.Literal[3], typing.Literal[1]], numpy.dtype[numpy.float64]
-        ] = ...,
-        quaternion: numpy.ndarray[
-            tuple[typing.Literal[4], typing.Literal[1]], numpy.dtype[numpy.float64]
-        ] = ...,
+        self, collision_geometry: CollisionGeometry, pose: mplib.pymp.Pose = ...
     ) -> None:
         """
         Construct a collision object with given collision geometry and transformation.
 
         :param collision_geometry: collision geometry of the object
-        :param position: position of the object
-        :param quaternion: quatenion of the object pose in [w, x, y, z] format
+        :param pose: pose of the object
         """
     def get_collision_geometry(self) -> CollisionGeometry: ...
-    def get_rotation(
-        self,
-    ) -> numpy.ndarray[
-        tuple[typing.Literal[3], typing.Literal[3]], numpy.dtype[numpy.float64]
-    ]: ...
-    def get_translation(
-        self,
-    ) -> numpy.ndarray[
-        tuple[typing.Literal[3], typing.Literal[1]], numpy.dtype[numpy.float64]
-    ]: ...
-    def set_transformation(
-        self,
-        arg0: numpy.ndarray[
-            tuple[typing.Literal[7], typing.Literal[1]], numpy.dtype[numpy.float64]
-        ],
-    ) -> None: ...
+    def get_pose(self) -> mplib.pymp.Pose:
+        """
+        Gets the current pose of the collision object in world
+
+        :return: The current pose of the collision object
+        """
+    def set_pose(self, pose: mplib.pymp.Pose) -> None:
+        """
+        Sets the pose of the collision object in world
+
+        :param pose: New pose of the collision object
+        """
+    @property
+    def pose(self) -> mplib.pymp.Pose:
+        """
+        Pose of the collision object in world
+        """
+    @pose.setter
+    def pose(self, arg1: mplib.pymp.Pose) -> None: ...
 
 class CollisionRequest:
     def __init__(
@@ -627,14 +624,7 @@ class FCLModel:
 
         :param names: list of link names in the order that you want to set.
         """
-    def update_collision_objects(
-        self,
-        link_poses: list[
-            numpy.ndarray[
-                tuple[typing.Literal[7], typing.Literal[1]], numpy.dtype[numpy.float64]
-            ]
-        ],
-    ) -> None:
+    def update_collision_objects(self, link_poses: list[mplib.pymp.Pose]) -> None:
         """
         Update the collision objects of the FCL model.
 
@@ -652,9 +642,21 @@ class FCLObject:
     https://moveit.picknik.ai/main/api/html/structcollision__detection_1_1FCLObject.html
     https://moveit.picknik.ai/main/api/html/structcollision__detection_1_1World_1_1Object.html
     """
-    @staticmethod
     @typing.overload
-    def __init__(*args, **kwargs) -> None:
+    def __init__(self, name: str) -> None:
+        """
+        Construct a new FCLObject with the given name
+
+        :param name: name of this FCLObject
+        """
+    @typing.overload
+    def __init__(
+        self,
+        name: str,
+        pose: mplib.pymp.Pose,
+        shapes: list[CollisionObject],
+        shape_poses: list[mplib.pymp.Pose],
+    ) -> None:
         """
         Construct a new FCLObject with the given name and shapes
 
@@ -663,25 +665,18 @@ class FCLObject:
         :param shapes: all collision shapes as a vector of ``fcl::CollisionObjectPtr``
         :param shape_poses: relative poses from this FCLObject to each collision shape
         """
-    @typing.overload
-    def __init__(self, name: str) -> None:
-        """
-        Construct a new FCLObject with the given name
-
-        :param name: name of this FCLObject
-        """
     @property
     def name(self) -> str:
         """
         Name of this FCLObject
         """
     @property
-    def pose(self) -> ...:
+    def pose(self) -> mplib.pymp.Pose:
         """
         Pose of this FCLObject. All shapes are relative to this pose
         """
     @property
-    def shape_poses(self) -> list[..., 3, 1, ...]:
+    def shape_poses(self) -> list[mplib.pymp.Pose]:
         """
         Relative poses from this FCLObject to each collision shape
         """

--- a/mplib/pymp/kinematics/kdl.pyi
+++ b/mplib/pymp/kinematics/kdl.pyi
@@ -6,6 +6,8 @@ import typing
 
 import numpy
 
+import mplib.pymp
+
 __all__ = ["KDLModel"]
 M = typing.TypeVar("M", bound=int)
 
@@ -27,9 +29,7 @@ class KDLModel:
         self,
         index: int,
         q_init: numpy.ndarray[tuple[M, typing.Literal[1]], numpy.dtype[numpy.float64]],
-        goal_pose: numpy.ndarray[
-            tuple[typing.Literal[7], typing.Literal[1]], numpy.dtype[numpy.float64]
-        ],
+        goal_pose: mplib.pymp.Pose,
     ) -> tuple[
         numpy.ndarray[tuple[M, typing.Literal[1]], numpy.dtype[numpy.float64]], int
     ]: ...
@@ -37,9 +37,7 @@ class KDLModel:
         self,
         index: int,
         q_init: numpy.ndarray[tuple[M, typing.Literal[1]], numpy.dtype[numpy.float64]],
-        goal_pose: numpy.ndarray[
-            tuple[typing.Literal[7], typing.Literal[1]], numpy.dtype[numpy.float64]
-        ],
+        goal_pose: mplib.pymp.Pose,
     ) -> tuple[
         numpy.ndarray[tuple[M, typing.Literal[1]], numpy.dtype[numpy.float64]], int
     ]: ...
@@ -47,9 +45,7 @@ class KDLModel:
         self,
         index: int,
         q_init: numpy.ndarray[tuple[M, typing.Literal[1]], numpy.dtype[numpy.float64]],
-        goal_pose: numpy.ndarray[
-            tuple[typing.Literal[7], typing.Literal[1]], numpy.dtype[numpy.float64]
-        ],
+        goal_pose: mplib.pymp.Pose,
         q_min: numpy.ndarray[tuple[M, typing.Literal[1]], numpy.dtype[numpy.float64]],
         q_max: numpy.ndarray[tuple[M, typing.Literal[1]], numpy.dtype[numpy.float64]],
     ) -> tuple[
@@ -60,11 +56,7 @@ class KDLModel:
         self,
         endpoints: list[str],
         q_init: numpy.ndarray[tuple[M, typing.Literal[1]], numpy.dtype[numpy.float64]],
-        goal_poses: list[
-            numpy.ndarray[
-                tuple[typing.Literal[7], typing.Literal[1]], numpy.dtype[numpy.float64]
-            ]
-        ],
+        goal_poses: list[mplib.pymp.Pose],
         q_min: numpy.ndarray[tuple[M, typing.Literal[1]], numpy.dtype[numpy.float64]],
         q_max: numpy.ndarray[tuple[M, typing.Literal[1]], numpy.dtype[numpy.float64]],
     ) -> tuple[

--- a/mplib/pymp/kinematics/pinocchio.pyi
+++ b/mplib/pymp/kinematics/pinocchio.pyi
@@ -6,6 +6,8 @@ import typing
 
 import numpy
 
+import mplib.pymp
+
 __all__ = ["PinocchioModel"]
 M = typing.TypeVar("M", bound=int)
 N = typing.TypeVar("N", bound=int)
@@ -52,9 +54,7 @@ class PinocchioModel:
     def compute_IK_CLIK(
         self,
         index: int,
-        pose: numpy.ndarray[
-            tuple[typing.Literal[7], typing.Literal[1]], numpy.dtype[numpy.float64]
-        ],
+        pose: mplib.pymp.Pose,
         q_init: numpy.ndarray[tuple[M, typing.Literal[1]], numpy.dtype[numpy.float64]],
         mask: list[bool] = [],
         eps: float = 1e-05,
@@ -73,7 +73,7 @@ class PinocchioModel:
 
         :param index: index of the link (in the order you passed to the constructor or
             the default order)
-        :param pose: desired pose of the link [x, y, z, qw, qx, qy, qz]
+        :param pose: desired pose of the link
         :param q_init: initial joint configuration
         :param mask: if the value at a given index is ``True``, the joint is *not* used
             in the IK
@@ -86,9 +86,7 @@ class PinocchioModel:
     def compute_IK_CLIK_JL(
         self,
         index: int,
-        pose: numpy.ndarray[
-            tuple[typing.Literal[7], typing.Literal[1]], numpy.dtype[numpy.float64]
-        ],
+        pose: mplib.pymp.Pose,
         q_init: numpy.ndarray[tuple[M, typing.Literal[1]], numpy.dtype[numpy.float64]],
         q_min: numpy.ndarray[tuple[M, typing.Literal[1]], numpy.dtype[numpy.float64]],
         q_max: numpy.ndarray[tuple[M, typing.Literal[1]], numpy.dtype[numpy.float64]],
@@ -109,7 +107,7 @@ class PinocchioModel:
 
         :param index: index of the link (in the order you passed to the constructor or
             the default order)
-        :param pose: desired pose of the link [x, y, z, qw, qx, qy, qz]
+        :param pose: desired pose of the link
         :param q_init: initial joint configuration
         :param q_min: minimum joint configuration
         :param q_max: maximum joint configuration
@@ -320,17 +318,13 @@ class PinocchioModel:
             to the constructor or the default order
         :return: name of the links
         """
-    def get_link_pose(
-        self, index: int
-    ) -> numpy.ndarray[
-        tuple[typing.Literal[7], typing.Literal[1]], numpy.dtype[numpy.float64]
-    ]:
+    def get_link_pose(self, index: int) -> mplib.pymp.Pose:
         """
-        Get the pose of the given link.
+        Get the pose of the given link in robot's base (root) frame.
 
         :param index: index of the link (in the order you passed to the constructor or
             the default order)
-        :return: pose of the link [x, y, z, qw, qx, qy, qz]
+        :return: pose of the link in robot's base (root) frame.
         """
     def get_random_configuration(
         self,

--- a/mplib/sapien_utils/conversion.py
+++ b/mplib/sapien_utils/conversion.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Optional, Sequence
 
 import numpy as np
-from sapien import Entity, Pose, Scene
+from sapien import Entity, Scene
 from sapien.physx import (
     PhysxArticulation,
     PhysxArticulationLinkComponent,
@@ -19,7 +19,7 @@ from sapien.physx import (
 from transforms3d.euler import euler2quat
 
 from ..planner import Planner
-from ..pymp import ArticulatedModel, PlanningWorld
+from ..pymp import ArticulatedModel, PlanningWorld, Pose
 from ..pymp.collision_detection.fcl import (
     Box,
     BVHModel,
@@ -27,6 +27,7 @@ from ..pymp.collision_detection.fcl import (
     CollisionObject,
     Convex,
     Cylinder,
+    FCLObject,
     Halfspace,
     Sphere,
     collide,
@@ -39,7 +40,9 @@ from .urdf_exporter import export_kinematic_chain_urdf
 
 class SapienPlanningWorld(PlanningWorld):
     def __init__(
-        self, sim_scene: Scene, planned_articulations: list[PhysxArticulation] = []
+        self,
+        sim_scene: Scene,
+        planned_articulations: list[PhysxArticulation] = [],  # noqa: B006
     ):
         """
         Creates an mplib.pymp.planning_world.PlanningWorld from a sapien.Scene.
@@ -56,12 +59,12 @@ class SapienPlanningWorld(PlanningWorld):
             urdf_str = export_kinematic_chain_urdf(articulation)
             srdf_str = export_srdf(articulation)
 
-            # Get all links with collision shapes at local_pose
-            collision_links = []  # [(link_name, [CollisionObject, ...]), ...]
-            for link in articulation.links:
-                col_objs = self.convert_sapien_col_shape(link)
-                if len(col_objs) > 0:
-                    collision_links.append((link.name, col_objs))
+            # Convert all links to FCLObject
+            collision_links = [
+                (link.name, fcl_obj)
+                for link in articulation.links
+                if (fcl_obj := self.convert_physx_component(link)) is not None
+            ]
 
             articulated_model = ArticulatedModel.create_from_urdf_string(
                 urdf_str,
@@ -81,76 +84,62 @@ class SapienPlanningWorld(PlanningWorld):
 
         for entity in actors:
             component = entity.find_component_by_type(PhysxRigidBaseComponent)
-            assert (
-                component is not None
-            ), f"No PhysxRigidBaseComponent found in {entity.name}: {entity.components=}"
-            assert not isinstance(
-                component, PhysxArticulationLinkComponent
-            ), f"Component should not be PhysxArticulationLinkComponent: {component=}"
-
-            # Convert collision shapes at current global pose
-            col_objs = self.convert_sapien_col_shape(component)  # type: ignore
-            # TODO: multiple collision shapes
-            assert len(col_objs) == 1, (
-                f"Should only have 1 collision object, got {len(col_objs)} shapes for "
-                f"entity '{entity.name}'"
+            assert component is not None, (
+                f"No PhysxRigidBaseComponent found in {entity.name}: "
+                f"{entity.components=}"
             )
 
-            self.add_normal_object(self.get_object_name(entity), col_objs[0])
+            # Convert collision shapes at current global pose
+            self.add_normal_object(
+                self.get_object_name(entity),
+                self.convert_physx_component(component),  # type: ignore
+            )
 
     def update_from_simulation(self, *, update_attached_object: bool = True) -> None:
         """
-        Updates planning_world articulations/objects pose with current Scene state
+        Updates PlanningWorld's articulations/objects pose with current Scene state.
+        Note that shape's local_pose is not updated.
+        If those are changed, please recreate a new SapienPlanningWorld instance.
 
         :param update_attached_object: whether to update the attached pose of
             all attached objects
         """
         for articulation in self._sim_scene.get_all_articulations():
-            # set_qpos to update poses
-            self.get_articulation(self.get_object_name(articulation)).set_qpos(
-                articulation.qpos  # type: ignore
-            )
+            if art := self.get_articulation(self.get_object_name(articulation)):
+                # set_qpos to update poses
+                art.set_qpos(articulation.qpos)  # type: ignore
+            else:
+                raise RuntimeError(
+                    f"Articulation {articulation.name} not found in PlanningWorld! "
+                    "The scene might have changed since last update."
+                )
 
         for entity in self._sim_scene.get_all_actors():
-            component = entity.find_component_by_type(PhysxRigidBaseComponent)
-            assert (
-                component is not None
-            ), f"No PhysxRigidBaseComponent found in {entity.name}: {entity.components=}"
-            assert not isinstance(
-                component, PhysxArticulationLinkComponent
-            ), f"Component should not be PhysxArticulationLinkComponent: {component=}"
+            object_name = self.get_object_name(entity)
 
-            shapes = component.collision_shapes  # type: ignore
-            # TODO: multiple collision shapes
-            assert len(shapes) == 1, (
-                f"Should only have 1 collision shape, got {len(shapes)} shapes for "
-                f"entity '{entity.name}'"
-            )
-            shape = shapes[0]
-
-            pose: Pose = entity.pose * shape.local_pose
-            # NOTE: Convert poses for Capsule/Cylinder
-            if isinstance(
-                shape, (PhysxCollisionShapeCapsule, PhysxCollisionShapeCylinder)
-            ):
-                pose = pose * Pose(q=euler2quat(0, np.pi / 2, 0))  # type: ignore
-
-            # handle attached object
-            if self.is_normal_object_attached(self.get_object_name(entity)):
-                attached_body = self.get_attached_object(self.get_object_name(entity))
-                if update_attached_object:
-                    parent_posevec = (
-                        attached_body.get_attached_articulation()
-                        .get_pinocchio_model()
-                        .get_link_pose(attached_body.get_attached_link_id())
+            # If entity is an attached object
+            if attached_body := self.get_attached_object(object_name):
+                if update_attached_object:  # update attached pose
+                    attached_body.pose = (
+                        attached_body.get_attached_link_global_pose().inv()
+                        * entity.pose  # type: ignore
                     )
-                    parent_pose = Pose(parent_posevec[:3], parent_posevec[3:])  # type: ignore
-                    pose = parent_pose.inv() * pose  # new attached pose
-                    attached_body.set_pose(np.hstack((pose.p, pose.q)))
                 attached_body.update_pose()
+            elif fcl_obj := self.get_normal_object(object_name):
+                # Overwrite the object
+                self.add_normal_object(
+                    object_name,
+                    FCLObject(
+                        object_name,
+                        entity.pose,  # type: ignore
+                        fcl_obj.shapes,
+                        fcl_obj.shape_poses,
+                    ),
+                )
             else:
-                self.get_normal_object(self.get_object_name(entity)).set_transformation(
-                    np.hstack((pose.p, pose.q))
+                raise RuntimeError(
+                    f"Entity {entity.name} not found in PlanningWorld! "
+                    "The scene might have changed since last update."
                 )
 
     @staticmethod
@@ -170,65 +159,64 @@ class SapienPlanningWorld(PlanningWorld):
             raise NotImplementedError(f"Unknown SAPIEN object type {type(obj)}")
 
     @staticmethod
-    def convert_sapien_col_shape(
-        component: PhysxRigidBaseComponent,
-    ) -> list[CollisionObject]:
-        """Converts a SAPIEN physx.PhysxRigidBaseComponent to an FCL CollisionObject
-        Returns a list of collision_obj at their current poses.
-
-        If the component is an articulation link, the returned collision_obj is at
-        the shape's local_pose.
-        Otherwise, the returned collision_obj is at the entity's global pose
+    def convert_physx_component(comp: PhysxRigidBaseComponent) -> FCLObject | None:
         """
-        shapes = component.collision_shapes
+        Converts a SAPIEN physx.PhysxRigidBaseComponent to an FCLObject.
+        All shapes in the returned FCLObject are already set at their world poses.
+
+        :param comp: a SAPIEN physx.PhysxRigidBaseComponent.
+        :return: an FCLObject containing all collision shapes in the Physx component.
+            If the component has no collision shapes, return ``None``.
+        """
+        shapes: list[CollisionObject] = []
+        shape_poses: list[Pose] = []
+        for shape in comp.collision_shapes:
+            shape_poses.append(shape.local_pose)  # type: ignore
+
+            if isinstance(shape, PhysxCollisionShapeBox):
+                c_geom = Box(side=shape.half_size * 2)
+            elif isinstance(shape, PhysxCollisionShapeCapsule):
+                c_geom = Capsule(radius=shape.radius, lz=shape.half_length * 2)
+                # NOTE: physx Capsule has x-axis along capsule height
+                # FCL Capsule has z-axis along capsule height
+                shape_poses[-1] *= Pose(q=euler2quat(0, np.pi / 2, 0))
+            elif isinstance(shape, PhysxCollisionShapeConvexMesh):
+                assert np.allclose(
+                    shape.scale, 1.0
+                ), f"Not unit scale {shape.scale}, need to rescale vertices?"
+                c_geom = Convex(vertices=shape.vertices, faces=shape.triangles)
+            elif isinstance(shape, PhysxCollisionShapeCylinder):
+                c_geom = Cylinder(radius=shape.radius, lz=shape.half_length * 2)
+                # NOTE: physx Cylinder has x-axis along cylinder height
+                # FCL Cylinder has z-axis along cylinder height
+                shape_poses[-1] *= Pose(q=euler2quat(0, np.pi / 2, 0))
+            elif isinstance(shape, PhysxCollisionShapePlane):
+                raise NotImplementedError(
+                    "Support for Plane collision is not implemented yet in mplib, "
+                    "need fcl::Plane"
+                )
+            elif isinstance(shape, PhysxCollisionShapeSphere):
+                c_geom = Sphere(radius=shape.radius)
+            elif isinstance(shape, PhysxCollisionShapeTriangleMesh):
+                c_geom = BVHModel()
+                c_geom.begin_model()
+                c_geom.add_sub_model(vertices=shape.vertices, faces=shape.triangles)  # type: ignore
+                c_geom.end_model()
+            else:
+                raise TypeError(f"Unknown shape type: {type(shape)}")
+            shapes.append(CollisionObject(c_geom))
+
         if len(shapes) == 0:
-            return []
+            return None
 
-        # NOTE: MPlib currently only supports 1 collision shape per object
-        # TODO: multiple collision shapes
-        assert len(shapes) == 1, (
-            f"Should only have 1 collision shape, got {len(shapes)} shapes for "
-            f"entity '{component.entity.name}'"
+        return FCLObject(
+            comp.name
+            if isinstance(comp, PhysxArticulationLinkComponent)
+            else SapienPlanningWorld.get_object_name(comp.entity),
+            comp.entity.pose,  # type: ignore
+            shapes,
+            shape_poses,
         )
-
-        shape = shapes[0]
-        if isinstance(component, PhysxArticulationLinkComponent):  # articulation link
-            pose = shape.local_pose
-        else:
-            pose = component.entity.pose * shape.local_pose
-
-        if isinstance(shape, PhysxCollisionShapeBox):
-            collision_geom = Box(side=shape.half_size * 2)
-        elif isinstance(shape, PhysxCollisionShapeCapsule):
-            collision_geom = Capsule(radius=shape.radius, lz=shape.half_length * 2)
-            # NOTE: physx Capsule has x-axis along capsule height
-            # FCL Capsule has z-axis along capsule height
-            pose = pose * Pose(q=euler2quat(0, np.pi / 2, 0))  # type: ignore
-        elif isinstance(shape, PhysxCollisionShapeConvexMesh):
-            assert np.allclose(
-                shape.scale, 1.0
-            ), f"Not unit scale {shape.scale}, need to rescale vertices?"
-            collision_geom = Convex(vertices=shape.vertices, faces=shape.triangles)
-        elif isinstance(shape, PhysxCollisionShapeCylinder):
-            collision_geom = Cylinder(radius=shape.radius, lz=shape.half_length * 2)
-            # NOTE: physx Cylinder has x-axis along cylinder height
-            # FCL Cylinder has z-axis along cylinder height
-            pose = pose * Pose(q=euler2quat(0, np.pi / 2, 0))  # type: ignore
-        elif isinstance(shape, PhysxCollisionShapePlane):
-            raise NotImplementedError(
-                "Support for Plane collision is not implemented yet in mplib, "
-                "need fcl::Plane"
-            )
-        elif isinstance(shape, PhysxCollisionShapeSphere):
-            collision_geom = Sphere(radius=shape.radius)
-        elif isinstance(shape, PhysxCollisionShapeTriangleMesh):
-            collision_geom = BVHModel()
-            collision_geom.begin_model()
-            collision_geom.add_sub_model(vertices=shape.vertices, faces=shape.triangles)
-            collision_geom.end_model()
-        else:
-            raise TypeError(f"Unknown shape type: {type(shape)}")
-        return [CollisionObject(collision_geom, pose.p, pose.q)]  # type: ignore
 
 
 class SapienPlanner(Planner):
@@ -303,7 +291,10 @@ class SapienPlanner(Planner):
 
     def update_from_simulation(self, *, update_attached_object: bool = True) -> None:
         """
-        Updates planning_world articulations/objects pose with current Scene state.
+        Updates PlanningWorld's articulations/objects pose with current Scene state.
+        Note that shape's local_pose is not updated.
+        If those are changed, please recreate a new SapienPlanningWorld instance.
+
         Directly calls ``SapienPlanningWorld.update_from_simulation()``
 
         :param update_attached_object: whether to update the attached pose of

--- a/pybind/collision_detection/fcl/pybind_fcl_model.cpp
+++ b/pybind/collision_detection/fcl/pybind_fcl_model.cpp
@@ -10,7 +10,6 @@
 
 #include "docstring/collision_detection/fcl/fcl_model.h"
 #include "mplib/collision_detection/fcl/fcl_model.h"
-#include "mplib/types.h"
 #include "pybind_macros.hpp"
 
 namespace py = pybind11;
@@ -58,9 +57,7 @@ void build_pyfcl_model(py::module &m) {
            DOC(mplib, collision_detection, fcl, FCLModelTpl,
                removeCollisionPairsFromSRDF))
 
-      .def("update_collision_objects",
-           py::overload_cast<const std::vector<Vector7<S>> &>(
-               &FCLModel::updateCollisionObjects, py::const_),
+      .def("update_collision_objects", &FCLModel::updateCollisionObjects,
            py::arg("link_poses"),
            DOC(mplib, collision_detection, fcl, FCLModelTpl, updateCollisionObjects))
 

--- a/pybind/core/pybind_articulated_model.cpp
+++ b/pybind/core/pybind_articulated_model.cpp
@@ -54,6 +54,8 @@ void build_pyarticulated_model(py::module &pymp) {
           py::arg("verbose") = false,
           DOC(mplib, ArticulatedModelTpl, createFromURDFString))
 
+      .def_property("name", &ArticulatedModel::getName, &ArticulatedModel::setName,
+                    DOC(mplib, ArticulatedModelTpl, name))
       .def("get_name", &ArticulatedModel::getName,
            DOC(mplib, ArticulatedModelTpl, getName))
       .def("set_name", &ArticulatedModel::setName, py::arg("name"),
@@ -85,14 +87,28 @@ void build_pyarticulated_model(py::module &pymp) {
 
       .def("get_move_group_qpos_dim", &ArticulatedModel::getQposDim,
            DOC(mplib, ArticulatedModelTpl, getQposDim))
+      .def_property_readonly("qpos", &ArticulatedModel::getQpos,
+                             DOC(mplib, ArticulatedModelTpl, qpos))
       .def("get_qpos", &ArticulatedModel::getQpos,
            DOC(mplib, ArticulatedModelTpl, getQpos))
       .def("set_qpos", &ArticulatedModel::setQpos, py::arg("qpos"),
            py::arg("full") = false, DOC(mplib, ArticulatedModelTpl, setQpos))
 
+      .def_property("base_pose", &ArticulatedModel::getBasePose,
+                    &ArticulatedModel::setBasePose,
+                    DOC(mplib, ArticulatedModelTpl, base_pose))
       .def("get_base_pose", &ArticulatedModel::getBasePose,
            DOC(mplib, ArticulatedModelTpl, getBasePose))
       .def("set_base_pose", &ArticulatedModel::setBasePose, py::arg("pose"),
+           DOC(mplib, ArticulatedModelTpl, setBasePose))
+
+      // pose is an alias of base_pose
+      .def_property("pose", &ArticulatedModel::getBasePose,
+                    &ArticulatedModel::setBasePose,
+                    DOC(mplib, ArticulatedModelTpl, base_pose))
+      .def("get_pose", &ArticulatedModel::getBasePose,
+           DOC(mplib, ArticulatedModelTpl, getBasePose))
+      .def("set_pose", &ArticulatedModel::setBasePose, py::arg("pose"),
            DOC(mplib, ArticulatedModelTpl, setBasePose))
 
       .def("update_SRDF", &ArticulatedModel::updateSRDF, py::arg("SRDF"),

--- a/pybind/core/pybind_attached_body.cpp
+++ b/pybind/core/pybind_attached_body.cpp
@@ -54,6 +54,12 @@ void build_pyattached_body(py::module &pymp) {
           },
           py::arg("pose"), DOC(mplib, AttachedBodyTpl, setPose))
       .def(
+          "get_attached_link_global_pose",
+          [](const AttachedBody &body) {
+            return Pose<S>(body.getAttachedLinkGlobalPose());
+          },
+          DOC(mplib, AttachedBodyTpl, getAttachedLinkGlobalPose))
+      .def(
           "get_global_pose",
           [](const AttachedBody &body) { return Pose<S>(body.getGlobalPose()); },
           DOC(mplib, AttachedBodyTpl, getGlobalPose))

--- a/pybind/docstring/collision_detection/fcl/fcl.h
+++ b/pybind/docstring/collision_detection/fcl/fcl.h
@@ -353,8 +353,23 @@ R"doc(
 Construct a collision object with given collision geometry and transformation.
 
 :param collision_geometry: collision geometry of the object
-:param position: position of the object
-:param quaternion: quatenion of the object pose in [w, x, y, z] format)doc";
+:param pose: pose of the object)doc";
+
+static const char *__doc_fcl_CollisionObject_pose =
+R"doc(
+Pose of the collision object in world)doc";
+
+static const char *__doc_fcl_CollisionObject_set_pose =
+R"doc(
+Sets the pose of the collision object in world
+
+:param pose: New pose of the collision object)doc";
+
+static const char *__doc_fcl_CollisionObject_get_pose =
+R"doc(
+Gets the current pose of the collision object in world
+
+:return: The current pose of the collision object)doc";
 
 /* ----- End of custom docstring section ----- */
 

--- a/pybind/docstring/collision_detection/fcl/fcl_model.h
+++ b/pybind/docstring/collision_detection/fcl/fcl_model.h
@@ -129,12 +129,6 @@ Update the collision objects of the FCL model.
 
 :param link_poses: list of link poses in the order of the link order)doc";
 
-static const char *__doc_mplib_collision_detection_fcl_FCLModelTpl_updateCollisionObjects_2 =
-R"doc(
-Update the collision objects of the FCL model.
-
-:param link_poses: list of link poses in the order of the link order)doc";
-
 /* ----- Begin of custom docstring section ----- */
 
 /* ----- End of custom docstring section ----- */

--- a/pybind/docstring/core/articulated_model.h
+++ b/pybind/docstring/core/articulated_model.h
@@ -64,9 +64,9 @@ Constructs an ArticulatedModel from URDF/SRDF strings and collision links
 
 static const char *__doc_mplib_ArticulatedModelTpl_getBasePose =
 R"doc(
-Get the base pose of the robot.
+Get the base (root) pose of the robot.
 
-:return: base pose of the robot in [x, y, z, qw, qx, qy, qz] format)doc";
+:return: base pose of the robot)doc";
 
 static const char *__doc_mplib_ArticulatedModelTpl_getFCLModel =
 R"doc(
@@ -130,9 +130,10 @@ Get the link names that the user has provided for planning.
 
 static const char *__doc_mplib_ArticulatedModelTpl_setBasePose =
 R"doc(
-Set the base pose of the robot.
+Set the base pose of the robot and update all collision links in the
+``FCLModel``.
 
-:param pose: base pose of the robot in [x, y, z, qw, qx, qy, qz] format)doc";
+:param pose: base pose of the robot)doc";
 
 static const char *__doc_mplib_ArticulatedModelTpl_setMoveGroup =
 R"doc(
@@ -156,7 +157,8 @@ Set name of the articulated model.
 
 static const char *__doc_mplib_ArticulatedModelTpl_setQpos =
 R"doc(
-Let the planner know the current joint positions.
+Set the current joint positions and update all collision links in the
+``FCLModel``.
 
 :param qpos: current qpos of all active joints or just the move group joints
 :param full: whether to set the full qpos or just the move group qpos. If full
@@ -170,6 +172,15 @@ Update the SRDF file to disable self-collisions.
 :param srdf: path to SRDF file, can be relative to the current working directory)doc";
 
 /* ----- Begin of custom docstring section ----- */
+
+static const char *__doc_mplib_ArticulatedModelTpl_name =
+R"doc(Name of the articulated model)doc";
+
+static const char *__doc_mplib_ArticulatedModelTpl_qpos =
+R"doc(Current qpos of all active joints)doc";
+
+static const char *__doc_mplib_ArticulatedModelTpl_base_pose =
+R"doc(The base (root) pose of the robot)doc";
 
 /* ----- End of custom docstring section ----- */
 

--- a/pybind/docstring/core/attached_body.h
+++ b/pybind/docstring/core/attached_body.h
@@ -45,11 +45,15 @@ Construct an attached body for a specified link.
 
 static const char *__doc_mplib_AttachedBodyTpl_getAttachedArticulation =
 R"doc(
-Gets the articulation this body is attached to)doc";
+Gets the articulation that this body is attached to)doc";
+
+static const char *__doc_mplib_AttachedBodyTpl_getAttachedLinkGlobalPose =
+R"doc(
+Gets the global pose of the articulation link that this body is attached to)doc";
 
 static const char *__doc_mplib_AttachedBodyTpl_getAttachedLinkId =
 R"doc(
-Gets the articulation this body is attached to)doc";
+Gets the articulation link id that this body is attached to)doc";
 
 static const char *__doc_mplib_AttachedBodyTpl_getGlobalPose =
 R"doc(

--- a/pybind/docstring/core/attached_body.h
+++ b/pybind/docstring/core/attached_body.h
@@ -85,6 +85,9 @@ Updates the global pose of the attached object using current state)doc";
 
 /* ----- Begin of custom docstring section ----- */
 
+static const char *__doc_mplib_AttachedBodyTpl_pose =
+R"doc(The attached pose (relative pose from attached link to object))doc";
+
 /* ----- End of custom docstring section ----- */
 
 #if defined(__GNUG__)

--- a/pybind/docstring/kinematics/pinocchio/pinocchio_model.h
+++ b/pybind/docstring/kinematics/pinocchio/pinocchio_model.h
@@ -69,7 +69,7 @@ Compute the inverse kinematics using close loop inverse kinematics.
 
 :param index: index of the link (in the order you passed to the constructor or
     the default order)
-:param pose: desired pose of the link [x, y, z, qw, qx, qy, qz]
+:param pose: desired pose of the link
 :param q_init: initial joint configuration
 :param mask: if the value at a given index is ``True``, the joint is *not* used
     in the IK
@@ -86,7 +86,7 @@ the given limits.
 
 :param index: index of the link (in the order you passed to the constructor or
     the default order)
-:param pose: desired pose of the link [x, y, z, qw, qx, qy, qz]
+:param pose: desired pose of the link
 :param q_init: initial joint configuration
 :param q_min: minimum joint configuration
 :param q_max: maximum joint configuration
@@ -275,11 +275,11 @@ Get the name of all the links.
 
 static const char *__doc_mplib_kinematics_pinocchio_PinocchioModelTpl_getLinkPose =
 R"doc(
-Get the pose of the given link.
+Get the pose of the given link in robot's base (root) frame.
 
 :param index: index of the link (in the order you passed to the constructor or
     the default order)
-:return: pose of the link [x, y, z, qw, qx, qy, qz])doc";
+:return: pose of the link in robot's base (root) frame.)doc";
 
 static const char *__doc_mplib_kinematics_pinocchio_PinocchioModelTpl_getModel =
 R"doc(

--- a/pybind/docstring/utils/conversion.h
+++ b/pybind/docstring/utils/conversion.h
@@ -34,19 +34,11 @@ R"doc(
 
 static const char *__doc_mplib_toIsometry =
 R"doc(
-Converts a pose_vec [px, py, pz, qw, qx, qy, qz] to an Eigen::Isometry3 matrix)doc";
+)doc";
 
 static const char *__doc_mplib_toIsometry_2 =
 R"doc(
 )doc";
-
-static const char *__doc_mplib_toIsometry_3 =
-R"doc(
-)doc";
-
-static const char *__doc_mplib_toPoseVec =
-R"doc(
-Converts an Eigen::Isometry3 matrix to a pose_vec [px, py, pz, qw, qx, qy, qz])doc";
 
 static const char *__doc_mplib_toSE3 =
 R"doc(

--- a/pybind/docstring/utils/pose.h
+++ b/pybind/docstring/utils/pose.h
@@ -24,7 +24,12 @@
 #pragma GCC diagnostic ignored "-Wunused-variable"
 #endif
 
-static const char *__doc_mplib_Pose = R"doc(Pose stored as a unit quaternion and a position vector)doc";
+static const char *__doc_mplib_Pose =
+R"doc(Pose stored as a unit quaternion and a position vector
+
+This struct is intended to be used only for interfacing with Python. Internally,
+``Pose`` is converted to and stored as ``Eigen::Isometry3`` which is used by all
+computations.)doc";
 
 static const char *__doc_mplib_Pose_Pose =
 R"doc(
@@ -43,6 +48,22 @@ Constructs a Pose with given position and quaternion
 
 :param p: position, format: (x, y, z)
 :param q: quaternion (can be unnormalized), format: (w, x, y, z))doc";
+
+static const char *__doc_mplib_Pose_Pose_4 =
+R"doc(
+Constructs a Pose from a given ``Eigen::Isometry3`` instance
+
+:param pose: an ``Eigen::Isometry3`` instance)doc";
+
+static const char *__doc_mplib_Pose_distance =
+R"doc(
+Computes the distance between two poses by ``norm(p1.p - p2.p) + min(norm(p1.q -
+p2.q), norm(p1.q + p2.q))`.
+
+The quaternion part has range [0, sqrt(2)].
+
+:param other: the other pose
+:return: the distance between the two poses)doc";
 
 static const char *__doc_mplib_Pose_inverse =
 R"doc(
@@ -66,9 +87,15 @@ static const char *__doc_mplib_Pose_p = R"doc(Position part of the Pose (x, y, z
 
 static const char *__doc_mplib_Pose_q = R"doc(Quaternion part of the Pose (w, x, y, z))doc";
 
+static const char *__doc_mplib_Pose_toIsometry =
+R"doc(
+Converts the Pose to an ``Eigen::Isometry3`` instance
+
+:return: an ``Eigen::Isometry3`` instance)doc";
+
 /* ----- Begin of custom docstring section ----- */
 
-static const char *__doc_mplib_Pose_Pose_4 =
+static const char *__doc_mplib_Pose_Pose_5 =
 R"doc(
 Constructs a Pose with given transformation matrix
 

--- a/pybind/docstring/utils/pose.h
+++ b/pybind/docstring/utils/pose.h
@@ -1,0 +1,111 @@
+#pragma once
+
+/*
+  This file contains docstrings for use in the Python bindings.
+  Do not edit! They were automatically extracted by mkdoc.py.
+ */
+
+#define __EXPAND(x)                                      x
+#define __COUNT(_1, _2, _3, _4, _5, _6, _7, COUNT, ...)  COUNT
+#define __VA_SIZE(...)                                   __EXPAND(__COUNT(__VA_ARGS__, 7, 6, 5, 4, 3, 2, 1, 0))
+#define __CAT1(a, b)                                     a ## b
+#define __CAT2(a, b)                                     __CAT1(a, b)
+#define __DOC1(n1)                                       __doc_##n1
+#define __DOC2(n1, n2)                                   __doc_##n1##_##n2
+#define __DOC3(n1, n2, n3)                               __doc_##n1##_##n2##_##n3
+#define __DOC4(n1, n2, n3, n4)                           __doc_##n1##_##n2##_##n3##_##n4
+#define __DOC5(n1, n2, n3, n4, n5)                       __doc_##n1##_##n2##_##n3##_##n4##_##n5
+#define __DOC6(n1, n2, n3, n4, n5, n6)                   __doc_##n1##_##n2##_##n3##_##n4##_##n5##_##n6
+#define __DOC7(n1, n2, n3, n4, n5, n6, n7)               __doc_##n1##_##n2##_##n3##_##n4##_##n5##_##n6##_##n7
+#define DOC(...)                                         __EXPAND(__EXPAND(__CAT2(__DOC, __VA_SIZE(__VA_ARGS__)))(__VA_ARGS__))
+
+#if defined(__GNUG__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-variable"
+#endif
+
+static const char *__doc_mplib_Pose = R"doc(Pose stored as a unit quaternion and a position vector)doc";
+
+static const char *__doc_mplib_Pose_Pose =
+R"doc(
+Constructs a default Pose with p = (0,0,0) and q = (1,0,0,0))doc";
+
+static const char *__doc_mplib_Pose_Pose_2 =
+R"doc(
+Constructs a Pose with given position and quaternion
+
+:param p: position, format: (x, y, z)
+:param q: quaternion (can be unnormalized), format: (w, x, y, z))doc";
+
+static const char *__doc_mplib_Pose_Pose_3 =
+R"doc(
+Constructs a Pose with given position and quaternion
+
+:param p: position, format: (x, y, z)
+:param q: quaternion (can be unnormalized), format: (w, x, y, z))doc";
+
+static const char *__doc_mplib_Pose_inverse =
+R"doc(
+Get the inserse Pose
+
+:return: the inverse Pose)doc";
+
+static const char *__doc_mplib_Pose_operator_imul =
+R"doc(
+Overloading operator *= for ``Pose<S> *= Pose<S>``)doc";
+
+static const char *__doc_mplib_Pose_operator_mul =
+R"doc(
+Overloading operator * for ``Pose<S> * Vector3<S>``)doc";
+
+static const char *__doc_mplib_Pose_operator_mul_2 =
+R"doc(
+Overloading operator * for ``Pose<S> * Pose<S>``)doc";
+
+static const char *__doc_mplib_Pose_p = R"doc(Position part of the Pose (x, y, z))doc";
+
+static const char *__doc_mplib_Pose_q = R"doc(Quaternion part of the Pose (w, x, y, z))doc";
+
+/* ----- Begin of custom docstring section ----- */
+
+static const char *__doc_mplib_Pose_Pose_4 =
+R"doc(
+Constructs a Pose with given transformation matrix
+
+:param matrix: a 4x4 transformation matrix)doc";
+
+static const char *__doc_mplib_Pose_to_transformation_matrix =
+R"doc(
+Constructs a transformation matrix from this Pose
+
+:return: a 4x4 transformation matrix)doc";
+
+static const char *__doc_mplib_Pose_set_p =
+R"doc(
+Sets the position part of the Pose
+
+:param p: position, format: (x, y, z))doc";
+
+static const char *__doc_mplib_Pose_get_p =
+R"doc(
+Gets the position part of the Pose
+
+:return: position, format: (x, y, z))doc";
+
+static const char *__doc_mplib_Pose_set_q =
+R"doc(
+Sets the quaternion part of the Pose
+
+:param q: quaternion (can be unnormalized), format: (w, x, y, z))doc";
+
+static const char *__doc_mplib_Pose_get_q =
+R"doc(
+Gets the quaternion part of the Pose
+
+:return: quaternion, format: (w, x, y, z))doc";
+
+/* ----- End of custom docstring section ----- */
+
+#if defined(__GNUG__)
+#pragma GCC diagnostic pop
+#endif

--- a/pybind/docstring/utils/pose.h
+++ b/pybind/docstring/utils/pose.h
@@ -98,8 +98,17 @@ Converts the Pose to an ``Eigen::Isometry3`` instance
 static const char *__doc_mplib_Pose_Pose_5 =
 R"doc(
 Constructs a Pose with given transformation matrix
+(4x4 np.ndarray with np.float64 dtype)
 
-:param matrix: a 4x4 transformation matrix)doc";
+:param matrix: a 4x4 np.float64 np.ndarray transformation matrix)doc";
+
+static const char *__doc_mplib_Pose_Pose_6 =
+R"doc(
+Constructs a Pose with given Python object that has ``p`` and ``q`` attributes
+(e.g., ``sapien.Pose``) or a 4x4 np.ndarray transformation matrix.
+
+:param obj: a Pose-like object with ``p`` and ``q`` attributes or
+    a 4x4 np.ndarray transformation matrix)doc";
 
 static const char *__doc_mplib_Pose_to_transformation_matrix =
 R"doc(

--- a/pybind/kinematics/pinocchio/pybind_pinocchio_model.cpp
+++ b/pybind/kinematics/pinocchio/pybind_pinocchio_model.cpp
@@ -95,9 +95,20 @@ void build_pypinocchio_model(py::module &m) {
            py::arg("qpos"),
            DOC(mplib, kinematics, pinocchio, PinocchioModelTpl,
                computeForwardKinematics))
-      .def("get_link_pose", &PinocchioModel::getLinkPose, py::arg("index"),
-           DOC(mplib, kinematics, pinocchio, PinocchioModelTpl, getLinkPose))
-      //.def("get_joint_pose", &PinocchioModel::getJointPose, py::arg("index"))
+      .def(
+          "get_link_pose",
+          [](const PinocchioModel &self, size_t index) {
+            return Pose<S>(self.getLinkPose(index));
+          },
+          py::arg("index"),
+          DOC(mplib, kinematics, pinocchio, PinocchioModelTpl, getLinkPose))
+      //.def(
+      //    "get_joint_pose",
+      //    [](const PinocchioModel &self, size_t index) {
+      //      return Pose<S>(self.getJointPose(index));
+      //    },
+      //    py::arg("index"),
+      //    DOC(mplib, kinematics, pinocchio, PinocchioModelTpl, getJointPose))
 
       .def("compute_full_jacobian", &PinocchioModel::computeFullJacobian,
            py::arg("qpos"),

--- a/pybind/pybind.cpp
+++ b/pybind/pybind.cpp
@@ -26,6 +26,7 @@ void build_pyarticulated_model(py::module &pymp);
 void build_pyattached_body(py::module &pymp);
 void build_pyplanning_world(py::module &pymp);
 void build_utils_random(py::module &pymp);
+void build_utils_pose(py::module &pymp);
 
 PYBIND11_MODULE(pymp, m) {
   m.doc() = "Motion planning python binding";
@@ -38,6 +39,7 @@ PYBIND11_MODULE(pymp, m) {
   build_pyattached_body(m);
   build_pyplanning_world(m);
   build_utils_random(m);
+  build_utils_pose(m);
 }
 
 }  // namespace mplib

--- a/pybind/pybind.cpp
+++ b/pybind/pybind.cpp
@@ -30,6 +30,8 @@ void build_utils_pose(py::module &pymp);
 
 PYBIND11_MODULE(pymp, m) {
   m.doc() = "Motion planning python binding";
+  // Need to be built first so other methods can use Pose<S>() as default argument value
+  build_utils_pose(m);
 
   collision_detection::build_pycollision_detection(m);
   kinematics::build_pykinematics(m);
@@ -39,7 +41,6 @@ PYBIND11_MODULE(pymp, m) {
   build_pyattached_body(m);
   build_pyplanning_world(m);
   build_utils_random(m);
-  build_utils_pose(m);
 }
 
 }  // namespace mplib

--- a/pybind/pybind_planning_world.cpp
+++ b/pybind/pybind_planning_world.cpp
@@ -95,18 +95,18 @@ void build_pyplanning_world(py::module &pymp) {
            DOC(mplib, PlanningWorldTpl, attachObject, 2))
       .def("attach_object",
            py::overload_cast<const std::string &, const std::string &, int,
-                             const Vector7<S> &, const std::vector<std::string> &>(
+                             const Pose<S> &, const std::vector<std::string> &>(
                &PlanningWorld::attachObject),
            py::arg("name"), py::arg("art_name"), py::arg("link_id"), py::arg("pose"),
            py::arg("touch_links"), DOC(mplib, PlanningWorldTpl, attachObject, 3))
       .def("attach_object",
            py::overload_cast<const std::string &, const std::string &, int,
-                             const Vector7<S> &>(&PlanningWorld::attachObject),
+                             const Pose<S> &>(&PlanningWorld::attachObject),
            py::arg("name"), py::arg("art_name"), py::arg("link_id"), py::arg("pose"),
            DOC(mplib, PlanningWorldTpl, attachObject, 4))
       .def("attach_object",
            py::overload_cast<const std::string &, const CollisionGeometryPtr &,
-                             const std::string &, int, const Vector7<S> &,
+                             const std::string &, int, const Pose<S> &,
                              const std::vector<std::string> &>(
                &PlanningWorld::attachObject),
            py::arg("name"), py::arg("p_geom"), py::arg("art_name"), py::arg("link_id"),
@@ -114,7 +114,7 @@ void build_pyplanning_world(py::module &pymp) {
            DOC(mplib, PlanningWorldTpl, attachObject, 5))
       .def("attach_object",
            py::overload_cast<const std::string &, const CollisionGeometryPtr &,
-                             const std::string &, int, const Vector7<S> &>(
+                             const std::string &, int, const Pose<S> &>(
                &PlanningWorld::attachObject),
            py::arg("name"), py::arg("p_geom"), py::arg("art_name"), py::arg("link_id"),
            py::arg("pose"), DOC(mplib, PlanningWorldTpl, attachObject, 6))

--- a/pybind/utils/pose.cpp
+++ b/pybind/utils/pose.cpp
@@ -28,7 +28,7 @@ void build_utils_pose(py::module &pymp) {
              return Pose<S> {mat.block<3, 1>(0, 3),
                              Quaternion<S>(mat.block<3, 3>(0, 0))};
            }),
-           py::arg("matrix"), DOC(mplib, Pose, Pose, 4))
+           py::arg("matrix"), DOC(mplib, Pose, Pose, 5))
       .def(
           "to_transformation_matrix",
           [](const Pose<S> &pose) {
@@ -69,6 +69,7 @@ void build_utils_pose(py::module &pymp) {
           DOC(mplib, Pose, get_q))
 
       .def("inv", &Pose<S>::inverse, DOC(mplib, Pose, inverse))
+      .def("distance", &Pose<S>::distance, py::arg("other"), DOC(mplib, Pose, distance))
       .def(py::self * Vector3<S>(), py::arg("v"), DOC(mplib, Pose, operator_mul))
       .def(py::self * py::self, py::arg("other"), DOC(mplib, Pose, operator_mul, 2))
       .def(py::self *= py::self, py::arg("other"), DOC(mplib, Pose, operator_imul))

--- a/pybind/utils/pose.cpp
+++ b/pybind/utils/pose.cpp
@@ -1,0 +1,97 @@
+#include "mplib/utils/pose.h"
+
+#include <memory>
+
+#include <pybind11/eigen.h>
+#include <pybind11/numpy.h>
+#include <pybind11/operators.h>
+#include <pybind11/pybind11.h>
+
+#include "docstring/utils/pose.h"
+#include "pybind_macros.hpp"
+
+namespace py = pybind11;
+
+namespace mplib {
+
+using Matrix4 = Eigen::Matrix<S, 4, 4, Eigen::RowMajor>;
+
+void build_utils_pose(py::module &pymp) {
+  auto PyPose =
+      py::class_<Pose<S>, std::shared_ptr<Pose<S>>>(pymp, "Pose", DOC(mplib, Pose));
+
+  PyPose.def(py::init<>(), DOC(mplib, Pose, Pose))
+      .def(py::init<const Vector3<S> &, const Vector4<S> &>(),
+           py::arg("p") = Vector3<S> {0.0, 0.0, 0.0},
+           py::arg("q") = Vector4<S> {1.0, 0.0, 0.0, 0.0}, DOC(mplib, Pose, Pose, 2))
+      .def(py::init([](const Matrix4 &mat) {
+             return Pose<S> {mat.block<3, 1>(0, 3),
+                             Quaternion<S>(mat.block<3, 3>(0, 0))};
+           }),
+           py::arg("matrix"), DOC(mplib, Pose, Pose, 4))
+      .def(
+          "to_transformation_matrix",
+          [](const Pose<S> &pose) {
+            Matrix4 mat = Matrix4::Identity();
+            mat.block<3, 3>(0, 0) = pose.q.toRotationMatrix();
+            mat.block<3, 1>(0, 3) = pose.p;
+            return mat;
+          },
+          DOC(mplib, Pose, to_transformation_matrix))
+
+      .def_readwrite("p", &Pose<S>::p, DOC(mplib, Pose, p))
+      .def(
+          "set_p", [](Pose<S> &pose, const Vector3<S> &p) { pose.p = p; }, py::arg("p"),
+          DOC(mplib, Pose, set_p))
+      .def(
+          "get_p", [](const Pose<S> &pose) { return pose.p; }, DOC(mplib, Pose, get_p))
+
+      .def_property(
+          "q",
+          [](const Pose<S> &pose) {
+            return Vector4<S> {pose.q.w(), pose.q.x(), pose.q.y(), pose.q.z()};
+          },
+          [](Pose<S> &pose, const Vector4<S> &q) {
+            pose.q = Quaternion<S> {q(0), q(1), q(2), q(3)}.normalized();
+          },
+          DOC(mplib, Pose, q))
+      .def(
+          "set_q",
+          [](Pose<S> &pose, const Vector4<S> &q) {
+            pose.q = Quaternion<S> {q(0), q(1), q(2), q(3)}.normalized();
+          },
+          py::arg("q"), DOC(mplib, Pose, set_q))
+      .def(
+          "get_q",
+          [](const Pose<S> &pose) {
+            return Vector4<S> {pose.q.w(), pose.q.x(), pose.q.y(), pose.q.z()};
+          },
+          DOC(mplib, Pose, get_q))
+
+      .def("inv", &Pose<S>::inverse, DOC(mplib, Pose, inverse))
+      .def(py::self * Vector3<S>(), py::arg("v"), DOC(mplib, Pose, operator_mul))
+      .def(py::self * py::self, py::arg("other"), DOC(mplib, Pose, operator_mul, 2))
+      .def(py::self *= py::self, py::arg("other"), DOC(mplib, Pose, operator_imul))
+
+      .def("__repr__",
+           [](const Pose<S> &pose) {
+             std::ostringstream oss;
+             oss << pose;
+             return oss.str();
+           })
+      .def(py::pickle(
+          [](const Pose<S> &p) {  // __getstate__
+            return py::make_tuple(p.p(0), p.p(1), p.p(2), p.q.w(), p.q.x(), p.q.y(),
+                                  p.q.z());
+          },
+          [](py::tuple t) {  // __setstate__
+            if (t.size() != 7) {
+              throw std::runtime_error("Invalid state!");
+            }
+            return Pose<S> {{t[0].cast<S>(), t[1].cast<S>(), t[2].cast<S>()},
+                            Quaternion<S> {t[3].cast<S>(), t[4].cast<S>(),
+                                           t[5].cast<S>(), t[6].cast<S>()}};
+          }));
+}
+
+}  // namespace mplib

--- a/src/collision_detection/fcl/collision_common.cpp
+++ b/src/collision_detection/fcl/collision_common.cpp
@@ -18,15 +18,17 @@ DEFINE_TEMPLATE_FCL_COMMON(float);
 DEFINE_TEMPLATE_FCL_COMMON(double);
 
 template <typename S>
-FCLObject<S>::FCLObject(const std::string &name, const Isometry3<S> &pose,
-                        const std::vector<fcl::CollisionObjectPtr<S>> &shapes,
-                        const std::vector<Isometry3<S>> &shape_poses)
-    : name(name), pose(pose), shapes(shapes), shape_poses(shape_poses) {
-  ASSERT(shapes.size() == shape_poses.size(),
+FCLObject<S>::FCLObject(const std::string &name_, const Pose<S> &pose_,
+                        const std::vector<fcl::CollisionObjectPtr<S>> &shapes_,
+                        const std::vector<Pose<S>> &shape_poses_)
+    : name(name_), pose(pose_.toIsometry()), shapes(shapes_) {
+  ASSERT(shapes_.size() == shape_poses_.size(),
          "shapes and shape_poses should have the same size");
-  // Update pose of the shapes
-  for (size_t i = 0; i < shapes.size(); i++)
-    shapes[i]->setTransform(pose * shape_poses[i]);
+  for (size_t i = 0; i < shapes_.size(); i++) {
+    shape_poses.push_back(shape_poses_[i].toIsometry());
+    // Update pose of the shapes
+    shapes_[i]->setTransform(pose * shape_poses[i]);
+  }
 }
 
 template <typename S>

--- a/src/collision_detection/fcl/fcl_model.cpp
+++ b/src/collision_detection/fcl/fcl_model.cpp
@@ -225,21 +225,9 @@ void FCLModelTpl<S>::removeCollisionPairsFromSRDFString(
 
 template <typename S>
 void FCLModelTpl<S>::updateCollisionObjects(
-    const std::vector<Vector7<S>> &link_poses) const {
+    const std::vector<Pose<S>> &link_poses) const {
   for (size_t i = 0; i < collision_objects_.size(); i++) {
-    const auto link_pose = toIsometry<S>(link_poses[collision_link_user_indices_[i]]);
-    const auto &fcl_obj = collision_objects_[i];
-    fcl_obj->pose = link_pose;
-    for (size_t j = 0; j < fcl_obj->shapes.size(); j++)
-      fcl_obj->shapes[j]->setTransform(link_pose * fcl_obj->shape_poses[j]);
-  }
-}
-
-template <typename S>
-void FCLModelTpl<S>::updateCollisionObjects(
-    const std::vector<Isometry3<S>> &link_poses) const {
-  for (size_t i = 0; i < collision_objects_.size(); i++) {
-    const auto link_pose = link_poses[collision_link_user_indices_[i]];
+    const auto link_pose = link_poses[collision_link_user_indices_[i]].toIsometry();
     const auto &fcl_obj = collision_objects_[i];
     fcl_obj->pose = link_pose;
     for (size_t j = 0; j < fcl_obj->shapes.size(); j++)

--- a/src/core/attached_body.cpp
+++ b/src/core/attached_body.cpp
@@ -11,14 +11,14 @@ DEFINE_TEMPLATE_ATTACHED_BODY(double);
 template <typename S>
 AttachedBodyTpl<S>::AttachedBodyTpl(const std::string &name, const FCLObjectPtr &object,
                                     const ArticulatedModelPtr &attached_articulation,
-                                    int attached_link_id, const Isometry3<S> &pose,
+                                    int attached_link_id, const Pose<S> &pose,
                                     const std::vector<std::string> &touch_links)
     : name_(name),
       object_(object),
       attached_articulation_(attached_articulation),
       pinocchio_model_(attached_articulation->getPinocchioModel()),
       attached_link_id_(attached_link_id),
-      pose_(pose),
+      pose_(pose.toIsometry()),
       touch_links_(touch_links) {
   updatePose();  // updates global pose using link_pose and attached_pose
 }

--- a/src/utils/conversion.cpp
+++ b/src/utils/conversion.cpp
@@ -4,8 +4,6 @@ namespace mplib {
 
 // Explicit Template Instantiation Definition ==========================================
 #define DEFINE_TEMPLATE_CONVERSION(S)                                            \
-  template Vector7<S> toPoseVec<S>(const Isometry3<S> &pose);                    \
-  template Isometry3<S> toIsometry<S>(const Vector7<S> &pose_vec);               \
   template Isometry3<S> toIsometry<S>(const pinocchio::SE3Tpl<S> &T);            \
   template Isometry3<S> toIsometry<S>(const urdf::Pose &M);                      \
   template pinocchio::SE3Tpl<S> toSE3<S>(const Isometry3<S> &T);                 \
@@ -15,26 +13,6 @@ namespace mplib {
 
 DEFINE_TEMPLATE_CONVERSION(float);
 DEFINE_TEMPLATE_CONVERSION(double);
-
-template <typename S>
-Vector7<S> toPoseVec(const Isometry3<S> &pose) {
-  const auto q = Quaternion<S> {pose.linear()};
-  Vector7<S> pose_vec;
-  pose_vec.template head<3>() = pose.translation();
-  pose_vec(3) = q.w();
-  pose_vec.template tail<3>() = q.vec();
-  return pose_vec;
-}
-
-template <typename S>
-Isometry3<S> toIsometry(const Vector7<S> &pose_vec) {
-  Isometry3<S> ret;
-  // NOTE: The quaternion is required to be normalized, otherwise it's UB
-  ret.linear() = Quaternion<S> {pose_vec[3], pose_vec[4], pose_vec[5], pose_vec[6]}
-                     .toRotationMatrix();
-  ret.translation() = pose_vec.template head<3>();
-  return ret;
-}
 
 template <typename S>
 Isometry3<S> toIsometry(const pinocchio::SE3Tpl<S> &T) {

--- a/tests/test_articulation.py
+++ b/tests/test_articulation.py
@@ -6,6 +6,7 @@ import trimesh
 from transforms3d.quaternions import mat2quat, quat2mat
 
 import mplib
+from mplib.pymp import Pose
 from mplib.pymp.collision_detection import fcl
 
 FILE_ABS_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -70,8 +71,8 @@ class TestArticulation(unittest.TestCase):
 
     def test_get_base_pose(self):
         base_pose = self.robot.get_base_pose()
-        self.assertIsInstance(base_pose, np.ndarray)
-        self.assertTrue(np.allclose(base_pose, np.array([0, 0, 0, 1, 0, 0, 0])))
+        self.assertIsInstance(base_pose, Pose)
+        self.assertEqual(base_pose.distance(Pose()), 0)
 
     def test_get_fcl_model(self):
         fcl_model = self.robot.get_fcl_model()
@@ -133,8 +134,9 @@ class TestArticulation(unittest.TestCase):
     def test_set_base_pose(self):
         pose = np.arange(7) / 10.0
         pose[3:] /= np.linalg.norm(pose[3:])
+        pose = Pose(pose[:3], pose[3:])
         self.robot.set_base_pose(pose)
-        self.assertTrue(np.allclose(self.robot.get_base_pose(), pose))
+        self.assertAlmostEqual(self.robot.get_base_pose().distance(pose), 0, places=3)
 
     def test_update_SRDF(self):
         self.robot.update_SRDF("")  # should not raise error

--- a/tests/test_fcl_model.py
+++ b/tests/test_fcl_model.py
@@ -40,9 +40,7 @@ class TestFCLModel(unittest.TestCase):
         for i, link_name in enumerate(self.collision_link_names):
             link_idx = self.pinocchio_model.get_link_names().index(link_name)
             link_pose = self.pinocchio_model.get_link_pose(link_idx)
-            self.model.get_collision_objects()[i].shapes[0].set_transformation(
-                link_pose
-            )
+            self.model.get_collision_objects()[i].shapes[0].set_pose(link_pose)
 
     def test_get_collision_objects(self):
         self.assertEqual(
@@ -50,13 +48,9 @@ class TestFCLModel(unittest.TestCase):
         )
         for i, link_name in enumerate(self.collision_link_names):
             pinocchio_idx = self.pinocchio_model.get_link_names().index(link_name)
-            pos = self.model.get_collision_objects()[i].shapes[0].get_translation()
-            quat = mat2quat(
-                self.model.get_collision_objects()[i].shapes[0].get_rotation()
-            )
+            fcl_pose = self.model.get_collision_objects()[i].shapes[0].get_pose()
             pinocchio_pose = self.pinocchio_model.get_link_pose(pinocchio_idx)
-            self.assertTrue(np.allclose(pos, pinocchio_pose[:3]))
-            self.assertAlmostEqual(abs(quat.dot(pinocchio_pose[3:])), 1)
+            self.assertAlmostEqual(fcl_pose.distance(pinocchio_pose), 0, places=3)
 
     def test_remove_collision_pairs_from_srdf(self):
         old_collision_pairs = self.model.get_collision_pairs()

--- a/tests/test_pinocchio.py
+++ b/tests/test_pinocchio.py
@@ -126,11 +126,11 @@ class TestPinocchioModel(unittest.TestCase):
             self.model.compute_forward_kinematics(qpos - perturbation)
             pose_minus = self.model.get_link_pose(link_idx)
 
-            position_diff = pose_plus[:3] - pose_minus[:3]
+            position_diff = pose_plus.get_p() - pose_minus.get_p()
             jacobian[:3, i] = position_diff / (2 * epsilon)
 
-            orientation_plus = pose_plus[3:]
-            orientation_minus = pose_minus[3:]
+            orientation_plus = pose_plus.get_q()
+            orientation_minus = pose_minus.get_q()
             # get the difference quaternion
             orientation_diff = qmult(orientation_plus, qinverse(orientation_minus))
             # get the axis-angle representation
@@ -138,7 +138,7 @@ class TestPinocchioModel(unittest.TestCase):
             jacobian[3:, i] = angle / (2 * epsilon) * axis
 
             self.model.compute_forward_kinematics(qpos)
-            curr_pos = self.model.get_link_pose(link_idx)[:3]
+            curr_pos = self.model.get_link_pose(link_idx).get_p()
             speed_due_to_rotation = np.cross(jacobian[3:, i], curr_pos)
             jacobian[:3, i] -= speed_due_to_rotation
 


### PR DESCRIPTION
- Added `mplib.Pose` similar to `sapien.Pose` but uses `float64` instead.
- Enabled implicit conversions from `sapien.Pose` and 4x4 np.ndarray transformation matrix to `mplib.Pose`
  - This means that you can pass in a `sapien.Pose`/`np.ndarray` to any method that requires a `mplib.Pose` and implicit conversions will jump in so there's no need to call `mplib.Pose()` constructor explicitly. (Maybe add tests for these as well?)
  - Although, `pyright`'s type checking will give error, which is expected and cannot be handled on MPlib side imo.

@Lexseal Please review this first and make a separate pull request for updating all examples/tests.
Support for Halfspace is not added here. It will have a separate pull request.